### PR TITLE
Sergio/default series v2

### DIFF
--- a/lib/siwapp/commons.ex
+++ b/lib/siwapp/commons.ex
@@ -176,8 +176,7 @@ defmodule Siwapp.Commons do
   @spec delete_series(%Series{}) :: {:ok, %Series{}} | {:error, any()}
   def delete_series(%Series{} = series) do
     if get_default_series() == series do
-      {:error,
-     "The series you're aiming to delete is the default series. \
+      {:error, "The series you're aiming to delete is the default series. \
       Change the default series first with change_default_series/1 function."}
     else
       Repo.delete(series)

--- a/lib/siwapp_web/live/modal_component.ex
+++ b/lib/siwapp_web/live/modal_component.ex
@@ -13,8 +13,6 @@ defmodule SiwappWeb.ModalComponent do
       phx-target={@myself}
       phx-page-loading>
 
-      <% IO.inspect assigns %>
-
       <div class="phx-modal-content">
         <%= live_patch raw("&times;"), to: @return_to, class: "phx-modal-close" %>
         <%= live_component @component, @opts %>

--- a/lib/siwapp_web/live/modal_component.ex
+++ b/lib/siwapp_web/live/modal_component.ex
@@ -13,6 +13,8 @@ defmodule SiwappWeb.ModalComponent do
       phx-target={@myself}
       phx-page-loading>
 
+      <% IO.inspect assigns %>
+
       <div class="phx-modal-content">
         <%= live_patch raw("&times;"), to: @return_to, class: "phx-modal-close" %>
         <%= live_component @component, @opts %>

--- a/lib/siwapp_web/live/series_live/form_component.ex
+++ b/lib/siwapp_web/live/series_live/form_component.ex
@@ -5,6 +5,7 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
 
   @impl true
   def update(%{series: series} = assigns, socket) do
+
     changeset = Commons.change_series(series)
 
     socket =
@@ -41,7 +42,7 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
       {:error, _msg} ->
         {:noreply,
          socket
-         |> put_flash(:info, "You can't delete the default series. Change it first in the list.")}
+         |> put_flash(:error, "You can't delete the default series.")}
     end
 
   end

--- a/lib/siwapp_web/live/series_live/form_component.ex
+++ b/lib/siwapp_web/live/series_live/form_component.ex
@@ -31,12 +31,19 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
 
   def handle_event("delete", %{"id" => id}, socket) do
     series = Commons.get_series(id)
-    {:ok, _series} = Commons.delete_series(series)
 
-    {:noreply,
-     socket
-     |> put_flash(:info, "Series was successfully destroyed.")
-     |> push_redirect(to: socket.assigns.return_to)}
+    case  Commons.delete_series(series) do
+      {:ok, _series} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Series was successfully destroyed.")
+         |> push_redirect(to: socket.assigns.return_to)}
+      {:error, _msg} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "You can't delete the default series. Change it first in the list.")}
+    end
+
   end
 
   defp save_series(socket, :edit, series_params) do

--- a/lib/siwapp_web/live/series_live/form_component.ex
+++ b/lib/siwapp_web/live/series_live/form_component.ex
@@ -5,7 +5,6 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
 
   @impl true
   def update(%{series: series} = assigns, socket) do
-
     changeset = Commons.change_series(series)
 
     socket =
@@ -33,18 +32,18 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
   def handle_event("delete", %{"id" => id}, socket) do
     series = Commons.get_series(id)
 
-    case  Commons.delete_series(series) do
+    case Commons.delete_series(series) do
       {:ok, _series} ->
         {:noreply,
          socket
          |> put_flash(:info, "Series was successfully destroyed.")
          |> push_redirect(to: socket.assigns.return_to)}
+
       {:error, _msg} ->
         {:noreply,
          socket
          |> put_flash(:error, "You can't delete the default series.")}
     end
-
   end
 
   defp save_series(socket, :edit, series_params) do

--- a/lib/siwapp_web/live/series_live/form_component.html.heex
+++ b/lib/siwapp_web/live/series_live/form_component.html.heex
@@ -1,4 +1,10 @@
 <fieldset class="fieldset">
+  <span class="alert alert-info" role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="info"><%= live_flash(@flash, :info) %></span>
+  <span class="alert alert-danger" role="alert"
+    phx-click="lv:clear-flash"
+    phx-value-key="error"><%= live_flash(@flash, :error) %></span>
   <h2><%= @title %></h2>
   <.form let={f} for={@changeset} id="series-form" phx-target={@myself} phx-change="validate" phx-submit="save">
 


### PR DESCRIPTION
Changes:
- Small refactoring
- Now you can't delete the default series. If you try, you'll see an error flash. See the image below.
- General flashes (the ones that are implemented when with the live layout inserted) don't work in live modal components. The only way I've been able to achieve it is inserting the flash HTML code inside the series form component. I see that this may not be the best way but I didn't find any other after trying lots of things.

![Screenshot 2021-12-23 at 17-29-10 Soledad-Series · Phoenix Framework](https://user-images.githubusercontent.com/49884623/147268220-a2570583-172d-4850-88cf-42f7d79590c7.png)

