### PR TITLE
Totals for invoice TDD

### DIFF
--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -121,6 +121,7 @@ defmodule Siwapp.Invoices.Invoice do
     |> validate_length(:email, max: 100)
     |> validate_length(:contact_person, max: 100)
     |> validate_length(:currency, max: 100)
+    |> calculate()
   end
 
   # you can't convert an existing invoice to draft
@@ -142,5 +143,35 @@ defmodule Siwapp.Invoices.Invoice do
       |> validate_required([:series_id, :issue_date])
       |> assoc_constraint(:customer)
     end
+  end
+
+  @doc """
+  Performs the totals calculations for net_amount, taxes_amounts and gross_amount fields.
+  """
+  @spec calculate(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def calculate(changeset) do
+    changeset
+    |> set_net_amount()
+    |> set_taxes_amounts()
+    # |> set_gross_amount()
+  end
+
+  defp set_net_amount(changeset) do
+    total_net_amount =
+      get_field(changeset, :items)
+      |> Enum.map(&(&1.net_amount))
+      |> Enum.sum()
+      |> round()
+
+    put_change(changeset, :net_amount, total_net_amount)
+  end
+
+  defp set_taxes_amounts(changeset) do
+    total_taxes_amounts =
+      get_field(changeset, :items)
+
+    IO.inspect total_taxes_amounts
+
+    changeset
   end
 end

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -79,6 +79,7 @@ defmodule Siwapp.Invoices.Invoice do
     field :net_amount, :integer, default: 0
     field :gross_amount, :integer, default: 0
     field :paid_amount, :integer, default: 0
+    field :taxes_amounts, :map, virtual: true, default: %{}
     field :draft, :boolean, default: false
     field :paid, :boolean, default: false
     field :sent_by_email, :boolean, default: false

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -78,7 +78,7 @@ defmodule Siwapp.Invoices.Item do
 
         taxes_amounts =
           for tax <- taxes, into: %{} do
-            {tax.name, tax.value * net_amount / 100}
+            {tax.name, net_amount * (tax.value / 100)}
           end
 
         put_change(changeset, :taxes_amount, taxes_amounts)

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -89,15 +89,23 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total net amount is the rounded sum of the net amounts of each item" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
-        items: [%{
-          quantity: 1,
-          unitary_cost: 133,
-          discount: 10},
-          %{
-            quantity: 1,
-            unitary_cost: 133,
-            discount: 10}]})
+      {:ok, invoice} =
+        Invoices.create(%{
+          name: "Melissa",
+          draft: true,
+          items: [
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10
+            },
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10
+            }
+          ]
+        })
 
       # 133-(133*(10/100)) = 119.70 (net_amount per item)
       # 119.70*2 = 239.40 (total net_amount)
@@ -105,17 +113,25 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total taxes amounts is a map with the total amount per tax" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
-        items: [%{
-          quantity: 1,
-          unitary_cost: 133,
-          discount: 10,
-          taxes: [%{name: "VAT"}]},
-          %{
-            quantity: 1,
-            unitary_cost: 133,
-            discount: 10,
-            taxes: [%{name: "VAT"}, %{name: "RETENTION"}]}]})
+      {:ok, invoice} =
+        Invoices.create(%{
+          name: "Melissa",
+          draft: true,
+          items: [
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10,
+              taxes: [%{name: "VAT"}]
+            },
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10,
+              taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
+            }
+          ]
+        })
 
       # 119.70 (net_amount per item)
       # 119.70*(21/100) = 25.137 (VAT per item)
@@ -124,17 +140,25 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
-        items: [%{
-          quantity: 1,
-          unitary_cost: 133,
-          discount: 10,
-          taxes: [%{name: "VAT"}]},
-          %{
-            quantity: 1,
-            unitary_cost: 133,
-            discount: 10,
-            taxes: [%{name: "VAT"}, %{name: "RETENTION"}]}]})
+      {:ok, invoice} =
+        Invoices.create(%{
+          name: "Melissa",
+          draft: true,
+          items: [
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10,
+              taxes: [%{name: "VAT"}]
+            },
+            %{
+              quantity: 1,
+              unitary_cost: 133,
+              discount: 10,
+              taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
+            }
+          ]
+        })
 
       # 239 (total net_amount)
       # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -113,7 +113,8 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total taxes amounts is a map with the total amount per tax" do
-      IO.puts "ESTE"
+      Commons.create_tax(%{name: "VAT", value: 21, default: true})
+      Commons.create_tax(%{name: "VAT", value: 21, default: true})
 
       {:ok, invoice} =
         Invoices.create(%{
@@ -142,6 +143,9 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
+      Commons.create_tax(%{name: "VAT", value: 21, default: true})
+      Commons.create_tax(%{name: "VAT", value: 21, default: true})
+
       {:ok, invoice} =
         Invoices.create(%{
           name: "Melissa",

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -55,4 +55,68 @@ defmodule Siwapp.InvoiceTest do
       assert {:ok, %Invoice{}} = Invoices.create(%{name: "Melissa", draft: true})
     end
   end
+
+  describe "Total amounts for an invoice" do
+    test "Total net amount of an invoice without items is 0" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      assert invoice.net_amount = 0
+    end
+
+    test "Total taxes amounts of an invoice without items is an empty map" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      assert invoice.taxes_amount = %{}
+    end
+
+    test "Total taxes amounts of an invoice whose items don't have any taxes associated is an empty map" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
+
+      assert invoice.taxes_amount = %{}
+    end
+
+    test "Total gross amount of an invoice without items is 0" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      assert invoice.gross_amount = 0
+    end
+
+    test "Total net amount is the rounded sum of the net amounts of each item" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
+
+      # 133-(133*(10/100)) = 119.70 (net_amount per item)
+      # 119.70*2 = 239.40 (total net_amount)
+      assert invoice.net_amount = 239
+    end
+
+    test "Total taxes amounts is a map with the total amount per tax" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}]})
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}, %{name: "RETENTION"}]})
+
+      # 119.70 (net_amount per item)
+      # 119.70*(21/100) = 25.137 (VAT per item)
+      # 119.70*(-15/100) = -17.955 (RETENTION for 2nd item)
+      assert invoice.taxes_amounts = %{"RETENTION" => -17.955, "VAT" => 50.274}
+    end
+
+    test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
+
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}]})
+      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}, %{name: "RETENTION"}]})
+
+      # 239 (total net_amount)
+      # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)
+      # 239 + 2*25.137 - 17.955 = 271.319 (total gross_amount)
+      assert invoice.gross_amount = 271
+    end
+
+  end
 end

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -71,7 +71,7 @@ defmodule Siwapp.InvoiceTest do
     test "Total taxes amounts of an invoice without items is an empty map" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      assert invoice.taxes_amount == %{}
+      assert invoice.taxes_amounts == %{}
     end
 
     test "Total taxes amounts of an invoice whose items don't have any taxes associated is an empty map" do
@@ -79,7 +79,7 @@ defmodule Siwapp.InvoiceTest do
 
       Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
 
-      assert invoice.taxes_amount == %{}
+      assert invoice.taxes_amounts == %{}
     end
 
     test "Total gross amount of an invoice without items is 0" do
@@ -113,6 +113,8 @@ defmodule Siwapp.InvoiceTest do
     end
 
     test "Total taxes amounts is a map with the total amount per tax" do
+      IO.puts "ESTE"
+
       {:ok, invoice} =
         Invoices.create(%{
           name: "Melissa",

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -39,14 +39,19 @@ defmodule Siwapp.InvoiceTest do
       {:ok, invoice} =
         Invoices.create(%{name: "Melissa", series_id: series.id, issue_date: Date.utc_today()})
 
-      changeset = Invoice.changeset(invoice, %{draft: true})
+      changeset =
+        Repo.preload(invoice, :items)
+        |> Invoice.changeset(%{draft: true})
 
       assert %{draft: ["can't be enabled, invoice is not new"]} = errors_on(changeset)
     end
 
     test "An existing draft can be re-marked as draft" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
-      changeset = Invoice.changeset(invoice, %{draft: true})
+
+      changeset =
+        Repo.preload(invoice, :items)
+        |> Invoice.changeset(%{draft: true})
 
       assert changeset.valid?
     end
@@ -60,13 +65,13 @@ defmodule Siwapp.InvoiceTest do
     test "Total net amount of an invoice without items is 0" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      assert invoice.net_amount = 0
+      assert invoice.net_amount == 0
     end
 
     test "Total taxes amounts of an invoice without items is an empty map" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      assert invoice.taxes_amount = %{}
+      assert invoice.taxes_amount == %{}
     end
 
     test "Total taxes amounts of an invoice whose items don't have any taxes associated is an empty map" do
@@ -74,70 +79,67 @@ defmodule Siwapp.InvoiceTest do
 
       Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
 
-      assert invoice.taxes_amount = %{}
+      assert invoice.taxes_amount == %{}
     end
 
     test "Total gross amount of an invoice without items is 0" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      assert invoice.gross_amount = 0
+      assert invoice.gross_amount == 0
     end
 
     test "Total net amount is the rounded sum of the net amounts of each item" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
-
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10})
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
+        items: [%{
+          quantity: 1,
+          unitary_cost: 133,
+          discount: 10},
+          %{
+            quantity: 1,
+            unitary_cost: 133,
+            discount: 10}]})
 
       # 133-(133*(10/100)) = 119.70 (net_amount per item)
       # 119.70*2 = 239.40 (total net_amount)
-      assert invoice.net_amount = 239
+      assert invoice.net_amount == 239
     end
 
     test "Total taxes amounts is a map with the total amount per tax" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
-
-      Invoices.create_item(invoice, %{
-        quantity: 1,
-        unitary_cost: 133,
-        discount: 10,
-        taxes: [%{name: "VAT"}]
-      })
-
-      Invoices.create_item(invoice, %{
-        quantity: 1,
-        unitary_cost: 133,
-        discount: 10,
-        taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
-      })
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
+        items: [%{
+          quantity: 1,
+          unitary_cost: 133,
+          discount: 10,
+          taxes: [%{name: "VAT"}]},
+          %{
+            quantity: 1,
+            unitary_cost: 133,
+            discount: 10,
+            taxes: [%{name: "VAT"}, %{name: "RETENTION"}]}]})
 
       # 119.70 (net_amount per item)
       # 119.70*(21/100) = 25.137 (VAT per item)
       # 119.70*(-15/100) = -17.955 (RETENTION for 2nd item)
-      assert invoice.taxes_amounts = %{"RETENTION" => -17.955, "VAT" => 50.274}
+      assert invoice.taxes_amounts == %{"RETENTION" => -17.955, "VAT" => 50.274}
     end
 
     test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
-      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
-
-      Invoices.create_item(invoice, %{
-        quantity: 1,
-        unitary_cost: 133,
-        discount: 10,
-        taxes: [%{name: "VAT"}]
-      })
-
-      Invoices.create_item(invoice, %{
-        quantity: 1,
-        unitary_cost: 133,
-        discount: 10,
-        taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
-      })
+      {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true,
+        items: [%{
+          quantity: 1,
+          unitary_cost: 133,
+          discount: 10,
+          taxes: [%{name: "VAT"}]},
+          %{
+            quantity: 1,
+            unitary_cost: 133,
+            discount: 10,
+            taxes: [%{name: "VAT"}, %{name: "RETENTION"}]}]})
 
       # 239 (total net_amount)
       # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)
       # 239 + 2*25.137 - 17.955 = 271.319 (total gross_amount)
-      assert invoice.gross_amount = 271
+      assert invoice.gross_amount == 271
     end
   end
 end

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -97,8 +97,19 @@ defmodule Siwapp.InvoiceTest do
     test "Total taxes amounts is a map with the total amount per tax" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}]})
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}, %{name: "RETENTION"}]})
+      Invoices.create_item(invoice, %{
+        quantity: 1,
+        unitary_cost: 133,
+        discount: 10,
+        taxes: [%{name: "VAT"}]
+      })
+
+      Invoices.create_item(invoice, %{
+        quantity: 1,
+        unitary_cost: 133,
+        discount: 10,
+        taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
+      })
 
       # 119.70 (net_amount per item)
       # 119.70*(21/100) = 25.137 (VAT per item)
@@ -109,14 +120,24 @@ defmodule Siwapp.InvoiceTest do
     test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
       {:ok, invoice} = Invoices.create(%{name: "Melissa", draft: true})
 
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}]})
-      Invoices.create_item(invoice, %{quantity: 1, unitary_cost: 133, discount: 10, taxes: [%{name: "VAT"}, %{name: "RETENTION"}]})
+      Invoices.create_item(invoice, %{
+        quantity: 1,
+        unitary_cost: 133,
+        discount: 10,
+        taxes: [%{name: "VAT"}]
+      })
+
+      Invoices.create_item(invoice, %{
+        quantity: 1,
+        unitary_cost: 133,
+        discount: 10,
+        taxes: [%{name: "VAT"}, %{name: "RETENTION"}]
+      })
 
       # 239 (total net_amount)
       # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)
       # 239 + 2*25.137 - 17.955 = 271.319 (total gross_amount)
       assert invoice.gross_amount = 271
     end
-
   end
 end

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -114,7 +114,7 @@ defmodule Siwapp.InvoiceTest do
 
     test "Total taxes amounts is a map with the total amount per tax" do
       Commons.create_tax(%{name: "VAT", value: 21, default: true})
-      Commons.create_tax(%{name: "VAT", value: 21, default: true})
+      Commons.create_tax(%{name: "RETENTION", value: -15})
 
       {:ok, invoice} =
         Invoices.create(%{
@@ -144,7 +144,7 @@ defmodule Siwapp.InvoiceTest do
 
     test "Total gross amount is the rounded sum of the total net amount and the taxes amounts" do
       Commons.create_tax(%{name: "VAT", value: 21, default: true})
-      Commons.create_tax(%{name: "VAT", value: 21, default: true})
+      Commons.create_tax(%{name: "RETENTION", value: -15})
 
       {:ok, invoice} =
         Invoices.create(%{
@@ -168,7 +168,7 @@ defmodule Siwapp.InvoiceTest do
 
       # 239 (total net_amount)
       # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)
-      # 239 + 2*25.137 - 17.955 = 271.319 (total gross_amount)
+      # 239 + 50.274 - 17.955 = 271.319 (total gross_amount)
       assert invoice.gross_amount == 271
     end
   end


### PR DESCRIPTION
Subo primero el test.

 - He creado un campo virtual en Invoice para guardar los taxes_amounts en un mapa ya totales sumados, que creo que es necesario para poder después ponerlo directamente en el formulario
 - Los redondeos se hacen en el total net_amount, y ya después en el total gross_amount, ¿es correcto?