### PR TITLE
taxes state in invoice form

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -34,6 +34,11 @@ let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfTo
 topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", info => topbar.show())
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
+window.addEventListener("phx:force-validate", (e) => {
+  document.getElementById(e.detail.id).dispatchEvent(
+    new Event("input", { bubbles: true })
+  )
+})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -88,12 +88,12 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     changeset =
       socket.assigns.changeset
-      |> Map.put(:changes, %{items: items})
+      |> Ecto.Changeset.put_change(:items, items)
 
     {:noreply, assign(socket, changeset: changeset)}
   end
 
-  defp get_existing_taxes(changeset, fi) do
+  defp get_selected_taxes(changeset, fi) do
     item =
       changeset
       |> Ecto.Changeset.get_field(:items)

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -89,7 +89,7 @@
         </div>
         <div class="column is-3-desktop is-half-mobile">
           <label class="label">Taxes</label>
-            <.live_component module={SiwappWeb.MultiselectComponent} id={"ms-#{fi.index}"} name={"invoice[items][#{fi.index}][taxes]"} selected={get_existing_taxes(@changeset, fi)} options={Siwapp.Commons.list_taxes_for_multiselect()} />
+            <.live_component module={SiwappWeb.MultiselectComponent} id={"ms-#{fi.index}"} name={"invoice[items][#{fi.index}][taxes]"} selected={get_selected_taxes(@changeset, fi)} options={Siwapp.Commons.list_taxes_for_multiselect()} />
         </div>
         <div class="column is-1-desktop is-full-mobile">
           <label class="label">Total</label>

--- a/lib/siwapp_web/live/multiselect_component.ex
+++ b/lib/siwapp_web/live/multiselect_component.ex
@@ -20,40 +20,38 @@ defmodule SiwappWeb.MultiselectComponent do
     ~H"""
     <div class="control msa-wrapper">
       <%= for {k, _v} <- @selected do %>
-        <input type="hidden" id="hidden_input" name={"#{@name}[]"} value={k}>
+        <input type="hidden" id={"invoice_items_#{@id}_taxes"} name={"#{@name}[]"} value={k}>
       <% end %>
       <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@id}")}>
         <span class="placeholder"></span>
         <%= for {k, v} <- @selected do %>
           <div class="tag-badge">
             <span><%= k %></span>
-            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{key: k, val: v})}>x</button>
+            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{id: @id, key: k, val: v})}>x</button>
           </div>
         <% end %>
       </div>
       <ul id={"tag-list-#{@id}"} class="tag-list" style="display: none;">
         <%= for {k, v} <- not_selected(@options, @selected) do %>
-          <li phx-click={JS.push("add", target: @myself, value: %{key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@id}")}><%= k %></li>
+          <li phx-click={JS.push("add", target: @myself, value: %{id: @id, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@id}")}><%= k %></li>
         <% end %>
       </ul>
     </div>
     """
   end
 
-  def handle_event("remove", %{"key" => key, "val" => value}, socket) do
-    {key, value} = convert({key, value})
-
-    {:noreply, update(socket, :selected, &MapSet.delete(&1, {key, value}))}
+  def handle_event("remove", %{"id" => id, "key" => key, "val" => value}, socket) do
+    {:noreply,
+     socket
+     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_#{id}_taxes"})
+     |> update(:selected, &MapSet.delete(&1, {key, value}))}
   end
 
-  def handle_event("add", %{"key" => key, "val" => value}, socket) do
-    {key, value} = convert({key, value})
-
-    {:noreply, update(socket, :selected, &MapSet.put(&1, {key, value}))}
-  end
-
-  defp convert({key, value}) do
-    {String.to_atom(key), value}
+  def handle_event("add", %{"id" => id, "key" => key, "val" => value}, socket) do
+    {:noreply,
+     socket
+     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_" <> id <> "_taxes"})
+     |> update(:selected, &MapSet.put(&1, {key, value}))}
   end
 
   defp not_selected(options, selected) do


### PR DESCRIPTION
fix #212 (Como el componente para introducir los taxes era un componente especial, no se llamaba al phx-change (función validate) cuando se metían nuevas taxes, y por tanto no se introducían estas taxes en los 'changes' del changeset. Por esta razón, cuando añadías un item nuevo y se actualizaban los datos según el contenido del changeset, como los taxes no estaban en el changeset, desaparecían)

Se ha solucionado forzando la llamada al phx-change mediante Javascript (push_event) cuando añades o eliminas una tax.