### PR TITLE
Taxes state in invoice form

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -34,6 +34,11 @@ let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfTo
 topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", info => topbar.show())
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
+window.addEventListener("phx:force-validate", (e) => {
+  document.getElementById(e.detail.id).dispatchEvent(
+    new Event("input", { bubbles: true })
+  )
+})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -34,11 +34,6 @@ let liveSocket = new LiveSocket("/live", Socket, { params: { _csrf_token: csrfTo
 topbar.config({ barColors: { 0: "#29d" }, shadowColor: "rgba(0, 0, 0, .3)" })
 window.addEventListener("phx:page-loading-start", info => topbar.show())
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
-window.addEventListener("phx:force-validate", (e) => {
-  document.getElementById(e.detail.id).dispatchEvent(
-    new Event("input", { bubbles: true })
-  )
-})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect()

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -110,7 +110,7 @@ defmodule Siwapp.Invoices.Item do
 
     taxes_from_attrs =
       (Map.get(attrs, :taxes) || Map.get(attrs, "taxes", []))
-      |> Enum.map(& if is_map(&1), do: &1.name, else: &1)
+      |> Enum.map(&if is_map(&1), do: &1.name, else: &1)
       |> Enum.map(&String.downcase/1)
 
     if taxes_from_data == [] or taxes_from_attrs != [] do
@@ -121,14 +121,14 @@ defmodule Siwapp.Invoices.Item do
   end
 
   defp add_tax_assoc(changeset, taxes) do
-      list_taxes = Commons.list_taxes()
-      taxes_assoc = Enum.filter(list_taxes, &(String.downcase(&1.name) in taxes))
-      database_taxes = Enum.map(list_taxes, &String.downcase(&1.name))
+    list_taxes = Commons.list_taxes()
+    taxes_assoc = Enum.filter(list_taxes, &(String.downcase(&1.name) in taxes))
+    database_taxes = Enum.map(list_taxes, &String.downcase(&1.name))
 
-      Enum.reduce(taxes, changeset, fn tax, acc_changeset ->
-        check_wrong_taxes(tax, acc_changeset, database_taxes)
-      end)
-      |> put_assoc(:taxes, taxes_assoc)
+    Enum.reduce(taxes, changeset, fn tax, acc_changeset ->
+      check_wrong_taxes(tax, acc_changeset, database_taxes)
+    end)
+    |> put_assoc(:taxes, taxes_assoc)
   end
 
   defp check_wrong_taxes(tax, changeset, database_taxes) do

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -73,8 +73,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     changeset = socket.assigns.changeset
     invoice = socket.assigns.invoice
 
-    items =
-      Ecto.Changeset.get_field(changeset, :items) ++ [Invoices.change_item(%Item{})]
+    items = Ecto.Changeset.get_field(changeset, :items) ++ [Invoices.change_item(%Item{})]
 
     {:noreply, assign(socket, changeset: update_changeset_with_items(changeset, invoice, items))}
   end
@@ -100,10 +99,15 @@ defmodule SiwappWeb.InvoicesLive.Edit do
       |> Enum.at(item_index)
       |> Map.put(:taxes, selected_taxes)
 
-    items = Enum.with_index(items, fn item, index -> if index == item_index, do: updated_item, else: item end)
+    items =
+      Enum.with_index(items, fn item, index ->
+        if index == item_index, do: updated_item, else: item
+      end)
 
-    {:noreply, assign(socket, changeset: update_changeset_with_items(changeset, socket.assigns.invoice, items))}
-
+    {:noreply,
+     assign(socket,
+       changeset: update_changeset_with_items(changeset, socket.assigns.invoice, items)
+     )}
   end
 
   defp update_changeset_with_items(changeset, invoice, items) do

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -88,12 +88,12 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     changeset =
       socket.assigns.changeset
-      |> Map.put(:changes, %{items: items})
+      |> Ecto.Changeset.put_change(:items, items)
 
     {:noreply, assign(socket, changeset: changeset)}
   end
 
-  defp get_existing_taxes(changeset, fi) do
+  defp get_selected_taxes(changeset, fi) do
     item =
       changeset
       |> Ecto.Changeset.get_field(:items)

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -89,7 +89,7 @@
         </div>
         <div class="column is-3-desktop is-half-mobile">
           <label class="label">Taxes</label>
-            <.live_component module={SiwappWeb.MultiselectComponent} id={"ms-#{fi.index}"} name={"invoice[items][#{fi.index}][taxes]"} selected={get_existing_taxes(@changeset, fi)} options={Siwapp.Commons.list_taxes_for_multiselect()} />
+            <.live_component module={SiwappWeb.MultiselectComponent} id={"ms-#{fi.index}"} name={"invoice[items][#{fi.index}][taxes]"} selected={get_selected_taxes(@changeset, fi)} options={Siwapp.Commons.list_taxes_for_multiselect()} />
         </div>
         <div class="column is-1-desktop is-full-mobile">
           <label class="label">Total</label>

--- a/lib/siwapp_web/live/multiselect_component.ex
+++ b/lib/siwapp_web/live/multiselect_component.ex
@@ -20,40 +20,38 @@ defmodule SiwappWeb.MultiselectComponent do
     ~H"""
     <div class="control msa-wrapper">
       <%= for {k, _v} <- @selected do %>
-        <input type="hidden" id="hidden_input" name={"#{@name}[]"} value={k}>
+        <input type="hidden" id={"invoice_items_#{@id}_taxes"} name={"#{@name}[]"} value={k}>
       <% end %>
       <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@id}")}>
         <span class="placeholder"></span>
         <%= for {k, v} <- @selected do %>
           <div class="tag-badge">
             <span><%= k %></span>
-            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{key: k, val: v})}>x</button>
+            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{id: @id, key: k, val: v})}>x</button>
           </div>
         <% end %>
       </div>
       <ul id={"tag-list-#{@id}"} class="tag-list" style="display: none;">
         <%= for {k, v} <- not_selected(@options, @selected) do %>
-          <li phx-click={JS.push("add", target: @myself, value: %{key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@id}")}><%= k %></li>
+          <li phx-click={JS.push("add", target: @myself, value: %{id: @id, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@id}")}><%= k %></li>
         <% end %>
       </ul>
     </div>
     """
   end
 
-  def handle_event("remove", %{"key" => key, "val" => value}, socket) do
-    {key, value} = convert({key, value})
-
-    {:noreply, update(socket, :selected, &MapSet.delete(&1, {key, value}))}
+  def handle_event("remove", %{"id" => id, "key" => key, "val" => value}, socket) do
+    {:noreply,
+     socket
+     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_#{id}_taxes"})
+     |> update(:selected, &MapSet.delete(&1, {key, value}))}
   end
 
-  def handle_event("add", %{"key" => key, "val" => value}, socket) do
-    {key, value} = convert({key, value})
-
-    {:noreply, update(socket, :selected, &MapSet.put(&1, {key, value}))}
-  end
-
-  defp convert({key, value}) do
-    {String.to_atom(key), value}
+  def handle_event("add", %{"id" => id, "key" => key, "val" => value}, socket) do
+    {:noreply,
+     socket
+     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_" <> id <> "_taxes"})
+     |> update(:selected, &MapSet.put(&1, {key, value}))}
   end
 
   defp not_selected(options, selected) do

--- a/lib/siwapp_web/live/multiselect_component.ex
+++ b/lib/siwapp_web/live/multiselect_component.ex
@@ -6,11 +6,13 @@ defmodule SiwappWeb.MultiselectComponent do
   alias Phoenix.LiveView.JS
 
   def update(assigns, socket) do
+    "ms-" <> index = assigns.id
+
     socket =
       socket
       |> assign(selected: MapSet.new(assigns.selected))
       |> assign(name: assigns.name)
-      |> assign(id: assigns.id)
+      |> assign(index: index)
       |> assign(options: MapSet.new(assigns.options))
 
     {:ok, socket}
@@ -20,38 +22,39 @@ defmodule SiwappWeb.MultiselectComponent do
     ~H"""
     <div class="control msa-wrapper">
       <%= for {k, _v} <- @selected do %>
-        <input type="hidden" id={"invoice_items_#{@id}_taxes"} name={"#{@name}[]"} value={k}>
+        <input type="hidden" name={"#{@name}[]"} value={k}>
       <% end %>
-      <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@id}")}>
+      <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@index}")}>
         <span class="placeholder"></span>
         <%= for {k, v} <- @selected do %>
           <div class="tag-badge">
             <span><%= k %></span>
-            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{id: @id, key: k, val: v})}>x</button>
+            <button type="button" phx-click={JS.push("remove", target: @myself, value: %{index: @index, key: k, val: v})}>x</button>
           </div>
         <% end %>
       </div>
-      <ul id={"tag-list-#{@id}"} class="tag-list" style="display: none;">
+      <ul id={"tag-list-#{@index}"} class="tag-list" style="display: none;">
         <%= for {k, v} <- not_selected(@options, @selected) do %>
-          <li phx-click={JS.push("add", target: @myself, value: %{id: @id, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@id}")}><%= k %></li>
+          <li phx-click={JS.push("add", target: @myself, value: %{index: @index, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@index}")}><%= k %></li>
         <% end %>
       </ul>
     </div>
     """
   end
 
-  def handle_event("remove", %{"id" => id, "key" => key, "val" => value}, socket) do
-    {:noreply,
-     socket
-     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_#{id}_taxes"})
-     |> update(:selected, &MapSet.delete(&1, {key, value}))}
+  def handle_event("remove", %{"index" => index, "key" => key, "val" => value}, socket) do
+    selected = MapSet.delete(socket.assigns.selected, {key, value})
+    send self(), {:taxes_updated, %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+
+    {:noreply, assign(socket, :selected, selected)}
   end
 
-  def handle_event("add", %{"id" => id, "key" => key, "val" => value}, socket) do
-    {:noreply,
-     socket
-     |> Phoenix.LiveView.push_event("force-validate", %{id: "invoice_items_" <> id <> "_taxes"})
-     |> update(:selected, &MapSet.put(&1, {key, value}))}
+  def handle_event("add", %{"index" => index, "key" => key, "val" => value}, socket) do
+    selected = MapSet.put(socket.assigns.selected, {key, value})
+
+    send self(), {:taxes_updated, %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+
+    {:noreply, assign(socket, :selected, selected)}
   end
 
   defp not_selected(options, selected) do

--- a/lib/siwapp_web/live/multiselect_component.ex
+++ b/lib/siwapp_web/live/multiselect_component.ex
@@ -44,7 +44,12 @@ defmodule SiwappWeb.MultiselectComponent do
 
   def handle_event("remove", %{"index" => index, "key" => key, "val" => value}, socket) do
     selected = MapSet.delete(socket.assigns.selected, {key, value})
-    send self(), {:taxes_updated, %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+
+    send(
+      self(),
+      {:taxes_updated,
+       %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+    )
 
     {:noreply, assign(socket, :selected, selected)}
   end
@@ -52,7 +57,11 @@ defmodule SiwappWeb.MultiselectComponent do
   def handle_event("add", %{"index" => index, "key" => key, "val" => value}, socket) do
     selected = MapSet.put(socket.assigns.selected, {key, value})
 
-    send self(), {:taxes_updated, %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+    send(
+      self(),
+      {:taxes_updated,
+       %{index: String.to_integer(index), selected: Enum.map(selected, fn {k, _v} -> k end)}}
+    )
 
     {:noreply, assign(socket, :selected, selected)}
   end


### PR DESCRIPTION
fix #212 (Como el componente para introducir los taxes era un componente especial, no se llamaba al phx-change (función validate) cuando se metían nuevas taxes, y por tanto no se introducían estas taxes en los 'changes' del changeset. Por esta razón, cuando añadías un item nuevo y se actualizaban los datos según el contenido del changeset, como los taxes no estaban en el changeset, desaparecían)

Se ha solucionado finalmente mandando un mensaje desde el componente de taxes al LiveView padre (InvoicesLive form) cada vez que se añade o se quita un tax. Cuando el LiveView lo recibe, lo que hace es actualizar el changeset incluyendo estos taxes nuevos en los items correspondientes.

Esta forma de actualizar el changeset con items nuevos (update_changeset_with_items/3), también se ha aplicado cuando añades o quitas un item, de forma que actualice el changeset también porque antes no lo hacía.