### PR TITLE
fix settings ecto.reset error

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -124,11 +124,11 @@ items = [
   }
 ]
 
+Enum.each(settings, &Settings.create(&1))
 Enum.each(customers, &Customers.create(&1))
 Enum.each(series, &Commons.create_series(&1))
 Enum.each(taxes, &Commons.create_tax(&1))
 Enum.each(invoices, &Invoices.create(&1))
 Enum.each(recurring_invoices, &RecurringInvoices.create(&1))
-Enum.each(settings, &Settings.create(&1))
 Enum.each(templates, &Templates.create(&1))
 Enum.each(items, &Invoices.create_item(Invoices.get!(1), &1))


### PR DESCRIPTION
El problema era que al crear una invoice y intentar asignarle un due date necesita el campo 'days_to_due' de settings, y para obtener el mapa de settings, en la función prepare_data/0, cuando va a obtener todas las keys, como no se han creado aún, da error.

Para solucionarlo se ha cambiado simplemente de orden la creación en seeds, para que los settings sea lo primero que se cree, ya que creo que no tiene sentido que se pueda hacer nada si no hay valores por defecto en los settings.