### PR TITLE
live sessions

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,10 +1,10 @@
 /* This file is for your main application CSS */
-
 @import "./phoenix.scss";
 @import "./graphic.css";
 @import "./multiselect.scss";
 @import "bulma";
-main.container {
+
+main.container{
   margin: 1em auto;
 }
 
@@ -14,31 +14,31 @@ main.container {
   z-index: 100;
 }
 
-fieldset.fieldset {
+fieldset.fieldset{
   margin-bottom: 3em;
 }
 
-.icon.table-icon {
+.icon.table-icon{
   display: revert;
   text-align: center;
 }
 
-td.table-span:not([align]) {
+td.table-span:not([align]){
   text-align: center;
 }
 
-.iframe.template {
+.iframe.template{
   width: 770px;
   height: 1090px;
   border: 2px solid #ced4da;
 }
 
 @media screen and (max-width: 1024px) {
-  .columns.is-multiline-mobile {
+  .columns.is-multiline-mobile{
     display: flex;
     flex-wrap: wrap;
   }
-  .navbar-mobile {
+  .navbar-mobile{
     position: fixed;
     z-index: 30;
     bottom: 0;

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -14,6 +14,14 @@ main.container{
   z-index: 100;
 }
 
+.navbar-item.has-dropdown div {
+  visibility: hidden;
+}
+
+.navbar-item.has-dropdown:hover div {
+  visibility: visible;
+}
+
 fieldset.fieldset{
   margin-bottom: 3em;
 }

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,41 +1,49 @@
 /* This file is for your main application CSS */
+
 @import "./phoenix.scss";
 @import "./graphic.css";
 @import "./multiselect.scss";
 @import "bulma";
-
-main.container{
+main.container {
   margin: 1em auto;
 }
 
-fieldset.fieldset{
+.navbar-new-button {
+  position: fixed;
+  top: 0px;
+  z-index: 100;
+}
+
+fieldset.fieldset {
   margin-bottom: 3em;
 }
 
-.icon.table-icon{
+.icon.table-icon {
   display: revert;
   text-align: center;
 }
 
-td.table-span:not([align]){
+td.table-span:not([align]) {
   text-align: center;
 }
 
-.iframe.template{
+.iframe.template {
   width: 770px;
   height: 1090px;
-  border: 2px solid #ced4da;  
+  border: 2px solid #ced4da;
 }
 
-@media screen and (max-width: 600px) {
-  .columns.is-multiline-mobile{
+@media screen and (max-width: 1024px) {
+  .columns.is-multiline-mobile {
     display: flex;
     flex-wrap: wrap;
   }
-
-  .navbar-mobile{
+  .navbar-mobile {
     position: fixed;
     z-index: 30;
     bottom: 0;
+  }
+  .navbar-new-button {
+    display: none;
   }
 }

--- a/lib/siwapp_web/live/series_live/form_component.html.heex
+++ b/lib/siwapp_web/live/series_live/form_component.html.heex
@@ -45,7 +45,7 @@
         <% end %>
       </p>
       <p class="control">
-        <%= link "Back", to: Routes.series_index_path(@socket, :index), class: "button is-dark" %>
+        <%= live_redirect "Back", to: Routes.series_index_path(@socket, :index), class: "button is-dark" %>
       </p>
       <p class="control">
         <%= submit "Save", class: "button is-success" %>

--- a/lib/siwapp_web/live/taxes_live/form_component.html.heex
+++ b/lib/siwapp_web/live/taxes_live/form_component.html.heex
@@ -37,7 +37,7 @@
           <% end %>
         </p>
         <p class="control">
-          <%= link "Back", to: Routes.taxes_index_path(@socket, :index), class: "button is-dark" %>
+          <%= live_redirect "Back", to: Routes.taxes_index_path(@socket, :index), class: "button is-dark" %>
         </p>
         <p class="control">
           <%= submit "Save", class: "button is-success" %>

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -92,42 +92,45 @@ defmodule SiwappWeb.Router do
 
   scope "/", SiwappWeb do
     pipe_through [:browser, :require_authenticated_user]
-    live "/", PageLive.Index, :index
 
-    get "/users/settings", UserSettingsController, :edit
-    put "/users/settings", UserSettingsController, :update
-    get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
+    live_session :user do
+      live "/", PageLive.Index, :index
 
-    live "/series", SeriesLive.Index, :index
-    live "/series/new", SeriesLive.Index, :new
-    live "/series/:id/edit", SeriesLive.Index, :edit
+      get "/users/settings", UserSettingsController, :edit
+      put "/users/settings", UserSettingsController, :update
+      get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
 
-    live "/taxes", TaxesLive.Index, :index
-    live "/taxes/new", TaxesLive.Index, :new
-    live "/taxes/:id/edit", TaxesLive.Index, :edit
+      live "/series", SeriesLive.Index, :index
+      live "/series/new", SeriesLive.Index, :new
+      live "/series/:id/edit", SeriesLive.Index, :edit
 
-    live "/invoices/new", InvoicesLive.Edit, :new
-    live "/invoices/:id/edit", InvoicesLive.Edit, :edit
-    get "/invoices/:id/show", PageController, :show_invoice
-    live "/invoices", InvoicesLive.Index, :index
-    get "/invoices/:id/download", PageController, :download
+      live "/taxes", TaxesLive.Index, :index
+      live "/taxes/new", TaxesLive.Index, :new
+      live "/taxes/:id/edit", TaxesLive.Index, :edit
 
-    live "/customers/new", CustomerLive.Edit, :new
-    live "/customers/:id/edit", CustomerLive.Edit, :edit
-    live "/customers/", CustomerLive.Index, :index
+      live "/invoices/new", InvoicesLive.Edit, :new
+      live "/invoices/:id/edit", InvoicesLive.Edit, :edit
+      get "/invoices/:id/show", PageController, :show_invoice
+      live "/invoices", InvoicesLive.Index, :index
+      get "/invoices/:id/download", PageController, :download
 
-    live "/templates", TemplatesLive.Index, :index
-    live "/templates/new", TemplatesLive.Edit, :new
-    live "/templates/:id/edit", TemplatesLive.Edit, :edit
+      live "/customers/new", CustomerLive.Edit, :new
+      live "/customers/:id/edit", CustomerLive.Edit, :edit
+      live "/customers/", CustomerLive.Index, :index
 
-    live "/recurring_invoices", RecurringInvoicesLive.Index, :index
-    live "/recurring_invoices/new", RecurringInvoicesLive.Edit, :new
-    live "/recurring_invoices/:id/edit", RecurringInvoicesLive.Edit, :edit
+      live "/templates", TemplatesLive.Index, :index
+      live "/templates/new", TemplatesLive.Edit, :new
+      live "/templates/:id/edit", TemplatesLive.Edit, :edit
 
-    get "/settings", SettingsController, :edit
-    post "/settings", SettingsController, :update
+      live "/recurring_invoices", RecurringInvoicesLive.Index, :index
+      live "/recurring_invoices/new", RecurringInvoicesLive.Edit, :new
+      live "/recurring_invoices/:id/edit", RecurringInvoicesLive.Edit, :edit
 
-    get "/iframe/:id", IframeController, :iframe
+      get "/settings", SettingsController, :edit
+      post "/settings", SettingsController, :update
+
+      get "/iframe/:id", IframeController, :iframe
+    end
   end
 
   scope "/", SiwappWeb do

--- a/lib/siwapp_web/templates/layout/app.html.heex
+++ b/lib/siwapp_web/templates/layout/app.html.heex
@@ -1,3 +1,8 @@
+<div class="navbar-end">
+  <div class="navbar-item navbar-new-button">
+    <%= new_button("New Invoice", Routes.invoices_edit_path(@conn, :new)) %>
+  </div>
+</div>
 <main class="container section has-navbar-fixed-bottom">
   <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
   <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,3 +1,8 @@
+<div class="navbar-end">
+  <div class="navbar-item navbar-new-button">
+    <%= shared_button(@socket) %>
+  </div>
+</div>
 <main class="container section has-navbar-fixed-bottom">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"

--- a/lib/siwapp_web/templates/layout/root.html.heex
+++ b/lib/siwapp_web/templates/layout/root.html.heex
@@ -28,8 +28,8 @@
 
         <div class="navbar-menu">
           <div class="navbar-start">
-            <%= link "Invoices", to: Routes.invoices_index_path(@conn, :index), class: "navbar-item" %>
-            <%= link "Recurring Invoices", to: Routes.recurring_invoices_index_path(@conn, :index), class: "navbar-item" %>
+            <%= live_redirect "Invoices", to: Routes.invoices_index_path(@conn, :index), class: "navbar-item" %>
+            <%= live_redirect "Recurring Invoices", to: Routes.recurring_invoices_index_path(@conn, :index), class: "navbar-item" %>
             <%= link "Customers", to: Routes.customer_index_path(@conn, :index), class: "navbar-item" %>
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">

--- a/lib/siwapp_web/templates/layout/root.html.heex
+++ b/lib/siwapp_web/templates/layout/root.html.heex
@@ -30,25 +30,25 @@
           <div class="navbar-start">
             <%= live_redirect "Invoices", to: Routes.invoices_index_path(@conn, :index), class: "navbar-item" %>
             <%= live_redirect "Recurring Invoices", to: Routes.recurring_invoices_index_path(@conn, :index), class: "navbar-item" %>
-            <%= link "Customers", to: Routes.customer_index_path(@conn, :index), class: "navbar-item" %>
+            <%= live_redirect "Customers", to: Routes.customer_index_path(@conn, :index), class: "navbar-item" %>
             <div class="navbar-item has-dropdown is-hoverable">
               <a class="navbar-link">
                 Account
               </a>
               <div class="navbar-dropdown">
-                <%= link "Profile", to: Routes.user_settings_path(@conn, :edit), class: "navbar-item" %>
+                <%= live_redirect "Profile", to: Routes.user_settings_path(@conn, :edit), class: "navbar-item" %>
                 <hr class="navbar-divider">
-                <%= link "Settings", to: Routes.settings_path(@conn, :edit), class: "navbar-item" %>
+                <%= live_redirect "Settings", to: Routes.settings_path(@conn, :edit), class: "navbar-item" %>
                 <hr class="navbar-divider">
-                <%= link "Series", to: Routes.series_index_path(@conn, :index), class: "navbar-item" %>
-                <%= link "Taxes", to: Routes.taxes_index_path(@conn, :index), class: "navbar-item" %>
-                <%= link "Templates", to: Routes.templates_index_path(@conn, :index), class: "navbar-item" %>
+                <%= live_redirect "Series", to: Routes.series_index_path(@conn, :index), class: "navbar-item" %>
+                <%= live_redirect "Taxes", to: Routes.taxes_index_path(@conn, :index), class: "navbar-item" %>
+                <%= live_redirect "Templates", to: Routes.templates_index_path(@conn, :index), class: "navbar-item" %>
                 <hr class="navbar-divider">
                 <a class="navbar-item">
                   Hooks
                 </a>
                 <hr class="navbar-divider">
-                <%= link "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "navbar-item" %>
+                <%= live_redirect "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "navbar-item" %>
               </div>
             </div>
           </div>

--- a/lib/siwapp_web/templates/layout/root.html.heex
+++ b/lib/siwapp_web/templates/layout/root.html.heex
@@ -52,12 +52,6 @@
               </div>
             </div>
           </div>
-
-          <div class="navbar-end">
-            <div class="navbar-item">
-              <%= shared_button(@conn) %>
-            </div>
-          </div>
         </div>
       </nav>
     <% end %>

--- a/lib/siwapp_web/views/layout_view.ex
+++ b/lib/siwapp_web/views/layout_view.ex
@@ -5,29 +5,29 @@ defmodule SiwappWeb.LayoutView do
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
 
-  def shared_button(conn) do
-    case conn.view do
+  def shared_button(socket) do
+    case socket.view do
       n when n in [SiwappWeb.SeriesLive.Index, SiwappWeb.SeriesLive.FormComponent] ->
-        new_button("New Series", Routes.series_index_path(conn, :new))
+        new_button("New Series", Routes.series_index_path(socket, :new))
 
       n when n in [SiwappWeb.CustomerLive.Index, SiwappWeb.CustomerLive.Edit] ->
-        new_button("New Customer", Routes.customer_edit_path(conn, :new))
+        new_button("New Customer", Routes.customer_edit_path(socket, :new))
 
       n when n in [SiwappWeb.TaxesLive.Index, SiwappWeb.TaxesLive.FormComponent] ->
-        new_button("New Tax", Routes.taxes_index_path(conn, :new))
+        new_button("New Tax", Routes.taxes_index_path(socket, :new))
 
       n when n in [SiwappWeb.TemplatesLive.Index, SiwappWeb.TemplatesLive.Edit] ->
-        new_button("New Template", Routes.templates_edit_path(conn, :new))
+        new_button("New Template", Routes.templates_edit_path(socket, :new))
 
       n when n in [SiwappWeb.RecurringInvoicesLive.Index, SiwappWeb.RecurringInvoicesLive.Edit] ->
-        new_button("New Recurring Invoice", Routes.recurring_invoices_edit_path(conn, :new))
+        new_button("New Recurring Invoice", Routes.recurring_invoices_edit_path(socket, :new))
 
       _ ->
-        new_button("New Invoice", Routes.invoices_edit_path(conn, :new))
+        new_button("New Invoice", Routes.invoices_edit_path(socket, :new))
     end
   end
 
   defp new_button(text, to) do
-    button(text, to: to, method: :get, class: "button is-primary")
+    live_redirect(text, to: to, class: "button is-primary")
   end
 end

--- a/lib/siwapp_web/views/layout_view.ex
+++ b/lib/siwapp_web/views/layout_view.ex
@@ -6,20 +6,20 @@ defmodule SiwappWeb.LayoutView do
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
 
   def shared_button(conn) do
-    case conn.request_path do
-      n when n in ["/series", "/series/new"] ->
+    case conn.view do
+      n when n in [SiwappWeb.SeriesLive.Index, SiwappWeb.SeriesLive.FormComponent] ->
         new_button("New Series", Routes.series_index_path(conn, :new))
 
-      n when n in ["/customers", "/customers/:id/edit", "/customers/new"] ->
+      n when n in [SiwappWeb.CustomerLive.Index, SiwappWeb.CustomerLive.Edit] ->
         new_button("New Customer", Routes.customer_edit_path(conn, :new))
 
-      n when n in ["/taxes", "/taxes/new"] ->
+      n when n in [SiwappWeb.TaxesLive.Index, SiwappWeb.TaxesLive.FormComponent] ->
         new_button("New Tax", Routes.taxes_index_path(conn, :new))
 
-      n when n in ["/templates", "/templates/new"] ->
+      n when n in [SiwappWeb.TemplatesLive.Index, SiwappWeb.TemplatesLive.Edit] ->
         new_button("New Template", Routes.templates_edit_path(conn, :new))
 
-      n when n in ["/recurring_invoices", "/recurring_invoices/new"] ->
+      n when n in [SiwappWeb.RecurringInvoicesLive.Index, SiwappWeb.RecurringInvoicesLive.Edit] ->
         new_button("New Recurring Invoice", Routes.recurring_invoices_edit_path(conn, :new))
 
       _ ->


### PR DESCRIPTION
solves #232 <-- leer el issue!!

Simplemente se ha creado una live session global de la app, y todos los enlaces en ella se hacen con live redirects, de forma que sólo carga el contenido nuevo de la app y el root layout se mantiene. Por esto mismo, se ha sacado los botones de "New XXX" del root layout.

También se han hecho unos pequeños ajustes en el CSS de cositas que no quedaban como antes al no recargar la página de forma completa cada vez.
