### PR TITLE
live sessions with nav outside root

### DIFF
--- a/lib/siwapp_web/live/series_live/form_component.html.heex
+++ b/lib/siwapp_web/live/series_live/form_component.html.heex
@@ -45,7 +45,7 @@
         <% end %>
       </p>
       <p class="control">
-        <%= link "Back", to: Routes.series_index_path(@socket, :index), class: "button is-dark" %>
+        <%= live_redirect "Back", to: Routes.series_index_path(@socket, :index), class: "button is-dark" %>
       </p>
       <p class="control">
         <%= submit "Save", class: "button is-success" %>

--- a/lib/siwapp_web/live/taxes_live/form_component.html.heex
+++ b/lib/siwapp_web/live/taxes_live/form_component.html.heex
@@ -37,7 +37,7 @@
           <% end %>
         </p>
         <p class="control">
-          <%= link "Back", to: Routes.taxes_index_path(@socket, :index), class: "button is-dark" %>
+          <%= live_redirect "Back", to: Routes.taxes_index_path(@socket, :index), class: "button is-dark" %>
         </p>
         <p class="control">
           <%= submit "Save", class: "button is-success" %>

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -92,42 +92,45 @@ defmodule SiwappWeb.Router do
 
   scope "/", SiwappWeb do
     pipe_through [:browser, :require_authenticated_user]
-    live "/", PageLive.Index, :index
 
-    get "/users/settings", UserSettingsController, :edit
-    put "/users/settings", UserSettingsController, :update
-    get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
+    live_session :user do
+      live "/", PageLive.Index, :index
 
-    live "/series", SeriesLive.Index, :index
-    live "/series/new", SeriesLive.Index, :new
-    live "/series/:id/edit", SeriesLive.Index, :edit
+      get "/users/settings", UserSettingsController, :edit
+      put "/users/settings", UserSettingsController, :update
+      get "/users/settings/confirm_email/:token", UserSettingsController, :confirm_email
 
-    live "/taxes", TaxesLive.Index, :index
-    live "/taxes/new", TaxesLive.Index, :new
-    live "/taxes/:id/edit", TaxesLive.Index, :edit
+      live "/series", SeriesLive.Index, :index
+      live "/series/new", SeriesLive.Index, :new
+      live "/series/:id/edit", SeriesLive.Index, :edit
 
-    live "/invoices/new", InvoicesLive.Edit, :new
-    live "/invoices/:id/edit", InvoicesLive.Edit, :edit
-    get "/invoices/:id/show", PageController, :show_invoice
-    live "/invoices", InvoicesLive.Index, :index
-    get "/invoices/:id/download", PageController, :download
+      live "/taxes", TaxesLive.Index, :index
+      live "/taxes/new", TaxesLive.Index, :new
+      live "/taxes/:id/edit", TaxesLive.Index, :edit
 
-    live "/customers/new", CustomerLive.Edit, :new
-    live "/customers/:id/edit", CustomerLive.Edit, :edit
-    live "/customers/", CustomerLive.Index, :index
+      live "/invoices/new", InvoicesLive.Edit, :new
+      live "/invoices/:id/edit", InvoicesLive.Edit, :edit
+      get "/invoices/:id/show", PageController, :show_invoice
+      live "/invoices", InvoicesLive.Index, :index
+      get "/invoices/:id/download", PageController, :download
 
-    live "/templates", TemplatesLive.Index, :index
-    live "/templates/new", TemplatesLive.Edit, :new
-    live "/templates/:id/edit", TemplatesLive.Edit, :edit
+      live "/customers/new", CustomerLive.Edit, :new
+      live "/customers/:id/edit", CustomerLive.Edit, :edit
+      live "/customers/", CustomerLive.Index, :index
 
-    live "/recurring_invoices", RecurringInvoicesLive.Index, :index
-    live "/recurring_invoices/new", RecurringInvoicesLive.Edit, :new
-    live "/recurring_invoices/:id/edit", RecurringInvoicesLive.Edit, :edit
+      live "/templates", TemplatesLive.Index, :index
+      live "/templates/new", TemplatesLive.Edit, :new
+      live "/templates/:id/edit", TemplatesLive.Edit, :edit
 
-    get "/settings", SettingsController, :edit
-    post "/settings", SettingsController, :update
+      live "/recurring_invoices", RecurringInvoicesLive.Index, :index
+      live "/recurring_invoices/new", RecurringInvoicesLive.Edit, :new
+      live "/recurring_invoices/:id/edit", RecurringInvoicesLive.Edit, :edit
 
-    get "/iframe/:id", IframeController, :iframe
+      get "/settings", SettingsController, :edit
+      post "/settings", SettingsController, :update
+
+      get "/iframe/:id", IframeController, :iframe
+    end
   end
 
   scope "/", SiwappWeb do

--- a/lib/siwapp_web/templates/layout/app.html.heex
+++ b/lib/siwapp_web/templates/layout/app.html.heex
@@ -1,3 +1,4 @@
+<%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @conn) %>
 <main class="container section has-navbar-fixed-bottom">
   <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
   <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,3 +1,4 @@
+<%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @socket) %>
 <main class="container section has-navbar-fixed-bottom">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"

--- a/lib/siwapp_web/templates/layout/nav.html.heex
+++ b/lib/siwapp_web/templates/layout/nav.html.heex
@@ -1,0 +1,48 @@
+<nav class="navbar is-fixed-top" role="navigation" aria-label="main navigation">
+  <div class="navbar-brand ">
+    <%=
+      img_tag(Routes.static_path(@socket_or_conn, "/images/logo.svg"))
+      |> link(to: Routes.page_index_path(@socket_or_conn, :index), class: "navbar-item")
+    %>
+    <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar-menu">
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+    </a>
+  </div>
+
+  <div class="navbar-menu">
+    <div class="navbar-start">
+      <%= live_render @socket_or_conn, SiwappWeb.SearchLive.Index, id: "search" %>
+      <%= live_redirect "Invoices", to: Routes.invoices_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+      <%= live_redirect "Recurring Invoices", to: Routes.recurring_invoices_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+      <%= live_redirect "Customers", to: Routes.customer_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+      <div class="navbar-item has-dropdown is-hoverable">
+        <a class="navbar-link">
+          Account
+        </a>
+        <div class="navbar-dropdown">
+          <%= live_redirect "Profile", to: Routes.user_settings_path(@socket_or_conn, :edit), class: "navbar-item" %>
+          <hr class="navbar-divider">
+          <%= live_redirect "Settings", to: Routes.settings_path(@socket_or_conn, :edit), class: "navbar-item" %>
+          <hr class="navbar-divider">
+          <%= live_redirect "Series", to: Routes.series_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+          <%= live_redirect "Taxes", to: Routes.taxes_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+          <%= live_redirect "Templates", to: Routes.templates_index_path(@socket_or_conn, :index), class: "navbar-item" %>
+          <hr class="navbar-divider">
+          <a class="navbar-item">
+            Hooks
+          </a>
+          <hr class="navbar-divider">
+          <%= live_redirect "Log out", to: Routes.user_session_path(@socket_or_conn, :delete), method: :delete, class: "navbar-item" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="navbar-end">
+      <div class="navbar-item">
+        <%= shared_button(@socket_or_conn) %>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/lib/siwapp_web/templates/layout/root.html.heex
+++ b/lib/siwapp_web/templates/layout/root.html.heex
@@ -12,56 +12,6 @@
   </head>
 
   <body class="has-navbar-fixed-top content" >
-    <%= if @current_user do %>
-      <nav class="navbar is-fixed-top"  role="navigation" aria-label="main navigation">
-        <div class="navbar-brand ">
-          <%=
-            img_tag(Routes.static_path(@conn, "/images/logo.svg"))
-            |> link(to: Routes.page_index_path(@conn, :index), class: "navbar-item")
-          %>
-          <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbar-menu">
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-          </a>
-        </div>
-
-        <div class="navbar-menu">
-          <div class="navbar-start">
-            <%= live_render @conn, SiwappWeb.SearchLive.Index %>
-            <%= link "Invoices", to: Routes.invoices_index_path(@conn, :index), class: "navbar-item" %>
-            <%= link "Recurring Invoices", to: Routes.recurring_invoices_index_path(@conn, :index), class: "navbar-item" %>
-            <%= link "Customers", to: Routes.customer_index_path(@conn, :index), class: "navbar-item" %>
-            <div class="navbar-item has-dropdown is-hoverable">
-              <a class="navbar-link">
-                Account
-              </a>
-              <div class="navbar-dropdown">
-                <%= link "Profile", to: Routes.user_settings_path(@conn, :edit), class: "navbar-item" %>
-                <hr class="navbar-divider">
-                <%= link "Settings", to: Routes.settings_path(@conn, :edit), class: "navbar-item" %>
-                <hr class="navbar-divider">
-                <%= link "Series", to: Routes.series_index_path(@conn, :index), class: "navbar-item" %>
-                <%= link "Taxes", to: Routes.taxes_index_path(@conn, :index), class: "navbar-item" %>
-                <%= link "Templates", to: Routes.templates_index_path(@conn, :index), class: "navbar-item" %>
-                <hr class="navbar-divider">
-                <a class="navbar-item">
-                  Hooks
-                </a>
-                <hr class="navbar-divider">
-                <%= link "Log out", to: Routes.user_session_path(@conn, :delete), method: :delete, class: "navbar-item" %>
-              </div>
-            </div>
-          </div>
-
-          <div class="navbar-end">
-            <div class="navbar-item">
-              <%= shared_button(@conn) %>
-            </div>
-          </div>
-        </div>
-      </nav>
-    <% end %>
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/siwapp_web/views/layout_view.ex
+++ b/lib/siwapp_web/views/layout_view.ex
@@ -5,29 +5,33 @@ defmodule SiwappWeb.LayoutView do
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
 
-  def shared_button(conn) do
-    case conn.request_path do
-      n when n in ["/series", "/series/new"] ->
-        new_button("New Series", Routes.series_index_path(conn, :new))
+  def shared_button(%Phoenix.LiveView.Socket{} = socket) do
+    case socket.view do
+      n when n in [SiwappWeb.SeriesLive.Index, SiwappWeb.SeriesLive.FormComponent] ->
+        new_button("New Series", Routes.series_index_path(socket, :new))
 
-      n when n in ["/customers", "/customers/:id/edit", "/customers/new"] ->
-        new_button("New Customer", Routes.customer_edit_path(conn, :new))
+      n when n in [SiwappWeb.CustomerLive.Index, SiwappWeb.CustomerLive.Edit] ->
+        new_button("New Customer", Routes.customer_edit_path(socket, :new))
 
-      n when n in ["/taxes", "/taxes/new"] ->
-        new_button("New Tax", Routes.taxes_index_path(conn, :new))
+      n when n in [SiwappWeb.TaxesLive.Index, SiwappWeb.TaxesLive.FormComponent] ->
+        new_button("New Tax", Routes.taxes_index_path(socket, :new))
 
-      n when n in ["/templates", "/templates/new"] ->
-        new_button("New Template", Routes.templates_edit_path(conn, :new))
+      n when n in [SiwappWeb.TemplatesLive.Index, SiwappWeb.TemplatesLive.Edit] ->
+        new_button("New Template", Routes.templates_edit_path(socket, :new))
 
-      n when n in ["/recurring_invoices", "/recurring_invoices/new"] ->
-        new_button("New Recurring Invoice", Routes.recurring_invoices_edit_path(conn, :new))
+      n when n in [SiwappWeb.RecurringInvoicesLive.Index, SiwappWeb.RecurringInvoicesLive.Edit] ->
+        new_button("New Recurring Invoice", Routes.recurring_invoices_edit_path(socket, :new))
 
       _ ->
-        new_button("New Invoice", Routes.invoices_edit_path(conn, :new))
+        new_button("New Invoice", Routes.invoices_edit_path(socket, :new))
     end
   end
 
+  def shared_button(%Plug.Conn{} = conn) do
+    new_button("New Invoice", Routes.invoices_edit_path(conn, :new))
+  end
+
   defp new_button(text, to) do
-    button(text, to: to, method: :get, class: "button is-primary")
+    live_redirect(text, to: to, method: :get, class: "button is-primary")
   end
 end


### PR DESCRIPTION
solves #232 

Finalmente, se ha sacado el nav del root layout, ahora está en el live layout (para las live views) y en el app layout (para las estáticas). De esta forma no podemos reutilizar nada, se carga todo en cada live view, pero así podemos gestionar mejor el cambio del "New XXX" button y la desaparición/aparición del buscador.

Falta cerrar la brecha de seguridad de autenticación al convertir todo en live session (#233) y que a partir de aqui @Pabloj20 ya incluya que el buscador aparezca y desaparezca según la view en la que se esté.