### PR TITLE
protect live session

### DIFF
--- a/lib/siwapp_web/live/user_auth_live.ex
+++ b/lib/siwapp_web/live/user_auth_live.ex
@@ -1,4 +1,5 @@
 defmodule SiwappWeb.UserAuthLive do
+  @moduledoc false
   import Phoenix.LiveView
   alias Siwapp.Accounts
 

--- a/lib/siwapp_web/live/user_auth_live.ex
+++ b/lib/siwapp_web/live/user_auth_live.ex
@@ -1,0 +1,12 @@
+defmodule SiwappWeb.UserAuthLive do
+  import Phoenix.LiveView
+  alias Siwapp.Accounts
+
+  def on_mount(:default, _params, %{"user_token" => user_token} = _session, socket) do
+    if current_user = Accounts.get_user_by_session_token(user_token) do
+      {:cont, assign(socket, :current_user, current_user)}
+    else
+      {:halt, redirect(socket, to: "/users/log_in")}
+    end
+  end
+end

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -104,7 +104,7 @@ defmodule SiwappWeb.Router do
   scope "/", SiwappWeb do
     pipe_through [:browser, :require_authenticated_user]
 
-    live_session :user do
+    live_session :user, on_mount: SiwappWeb.UserAuthLive do
       live "/", PageLive.Index, :index
 
       get "/users/settings", UserSettingsController, :edit


### PR DESCRIPTION
fixes #233 <- leer el issue!!

Se arregla indicándole que cada vez que cambie de live view ejecute el método on_mount de UserAuthLive, que verifica que el usuario sigue autenticado.