### PR TITLE
Mejora del contexto de Settings

### DIFF
--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -145,8 +145,8 @@ defmodule Siwapp.Invoices.Invoice do
       changeset
     else
       issue_date = get_field(changeset, :issue_date)
-      settings = Siwapp.Settings.prepare_data()
-      due_date = Date.add(issue_date, String.to_integer(settings.days_to_due))
+      days_to_due = Siwapp.Settings.value(:days_to_due)
+      due_date = Date.add(issue_date, String.to_integer(days_to_due))
 
       put_change(changeset, :due_date, due_date)
     end

--- a/lib/siwapp/settings.ex
+++ b/lib/siwapp/settings.ex
@@ -75,7 +75,6 @@ defmodule Siwapp.Settings do
   Returns the value of the setting associated to key (atom or string). Returns nil if
   this setting doesn't exist
   """
-  @spec value(atom | binary) :: nil | Setting.t()
   def value(key) do
     case get(key) do
       nil -> nil

--- a/lib/siwapp/settings.ex
+++ b/lib/siwapp/settings.ex
@@ -2,40 +2,78 @@ defmodule Siwapp.Settings do
   alias Siwapp.Repo
   alias Siwapp.Settings.{Setting, SettingBundle}
 
-  @moduledoc false
+  @moduledoc """
+  This module manage settings. For those with predefined keys in SettingBundle,
+  which are also initialized using seeds, bundle operations can be used directly
+  to change the full set of contemplated settings. Extra settings can be saved, as
+  long as they have unique key, even though they won't be accessible to user using
+  the form but only to developers using terminal.
+  """
 
   @doc """
-  Creates a setting given a key
+  Starts a setting given a key-value tuple (used only in seeds)
   """
-  @spec create({atom, binary}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
+  @spec create({atom | binary, binary}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
   def create({key, value}) do
     %Setting{}
     |> change({to_string(key), value})
     |> Repo.insert()
   end
 
+  @doc """
+  Performs the SettingBundle changeset
+  """
   def change_bundle(%SettingBundle{} = setting_bundle, attrs \\ %{}) do
     SettingBundle.changeset(setting_bundle, attrs)
   end
 
   @doc """
-  Function to prepare_data which will be changed to fill the form
+  Returns current SettingBundle (which is also useful to be changed and fill the SettingBundle form)
   """
-  def prepare_data, do: struct(SettingBundle, Enum.zip(SettingBundle.labels(), values()))
+  def current_bundle, do: struct(SettingBundle, Enum.zip(SettingBundle.labels(), values()))
 
   @doc """
-  Function which takes the filled form and applies proper actions
+  Takes a map of SettingBundle's parameters and saves each associated Setting if possible.
+  Informs of the possibility to save those settings and returns the setting_bundle changeset
   """
-  def apply_user_settings(attrs) do
-    changeset = change_bundle(prepare_data(), attrs)
+  def apply_user_bundle(attrs) do
+    changeset = change_bundle(current_bundle(), attrs)
 
     if changeset.valid? do
       changes = Map.to_list(changeset.changes)
       Enum.each(changes, fn {k, v} -> update({k, v}) end)
       {:ok, changeset}
     else
-      {:error, changeset}
+      {:error, %{changeset | action: :insert}}
     end
+  end
+
+  @doc """
+  Returns the setting under the given key (atom or string)
+  """
+  @spec get(atom | binary) :: Setting.t() | nil
+  def get(key),
+    do: Repo.get_by(Setting, key: to_string(key))
+
+  @doc """
+  Returns the value of the setting associated to key (atom or string). Returns nil if
+  this setting doesn't exist
+  """
+  def value(key) do
+    case get(key) do
+      nil -> nil
+      setting -> setting.value
+    end
+  end
+
+  @doc """
+  Takes key-value tuple and updates the value of the Setting determined by key
+  """
+  @spec update({atom, any}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
+  def update({key, value}) do
+    get(key)
+    |> change({to_string(key), to_string(value)})
+    |> Repo.update()
   end
 
   @spec change(Setting.t(), {binary, binary}) :: Ecto.Changeset.t()
@@ -43,20 +81,9 @@ defmodule Siwapp.Settings do
     Setting.changeset(setting, adequate_attrs(attrs))
   end
 
-  @spec update({atom, any}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
-  defp update({key, value}) do
-    get(key)
-    |> change({to_string(key), to_string(value)})
-    |> Repo.update()
-  end
-
-  @spec get(atom) :: Setting.t()
-  defp get(key),
-    do: Repo.get_by(Setting, key: to_string(key))
-
   @spec values :: [nil | binary]
   defp values do
-    for key <- SettingBundle.labels(), do: get(key).value
+    for key <- SettingBundle.labels(), do: value(key)
   end
 
   @spec adequate_attrs({binary, binary}) :: map

--- a/lib/siwapp/settings/setting.ex
+++ b/lib/siwapp/settings/setting.ex
@@ -12,7 +12,10 @@ defmodule Siwapp.Settings.Setting do
           updated_at: nil | DateTime.t()
         }
 
-  @moduledoc false
+  @moduledoc """
+  A Setting's a schema used to manage settings database, which has key and value columns. Therefore,
+  no matter which key, values are always strings.
+  """
 
   schema "settings" do
     field :key, :string

--- a/lib/siwapp/settings/setting_bundle.ex
+++ b/lib/siwapp/settings/setting_bundle.ex
@@ -25,17 +25,16 @@ defmodule Siwapp.Settings.SettingBundle do
 
   def changeset(setting_bundle, attrs \\ %{}) do
     {setting_bundle, fields_map()}
-    |> cast(attrs, labels())
+    |> cast(attrs, @labels)
     |> validate_email()
     # Example list of currency, will be updated to whole
     |> validate_inclusion(:currency, ["USD", "EUR"])
   end
 
-  @spec labels :: [atom]
-  def labels, do: @labels
   @spec fields_map :: map
   defp fields_map, do: Map.new(@fields_keywordlist)
 
+  @spec validate_email(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_email(changeset) do
     changeset
     |> validate_format(:company_email, ~r/^[^\s]+@[^\s]+$/,

--- a/lib/siwapp/settings/setting_bundle.ex
+++ b/lib/siwapp/settings/setting_bundle.ex
@@ -1,7 +1,11 @@
 defmodule Siwapp.Settings.SettingBundle do
   import Ecto.Changeset
 
-  @moduledoc false
+  @moduledoc """
+  SettingBundle is the data structure to manage SettingsController form operations. It's a struct, whose keys consist of
+  all current settings available to change via form or terminal, updating settings values' of those already stored in db
+  (which are initialized in the seeds)
+  """
 
   @fields_keywordlist [
     company: :string,

--- a/lib/siwapp_web/controllers/settings_controller.ex
+++ b/lib/siwapp_web/controllers/settings_controller.ex
@@ -4,7 +4,7 @@ defmodule SiwappWeb.SettingsController do
   alias Siwapp.Settings
 
   def edit(conn, _params) do
-    data = Settings.prepare_data()
+    data = Settings.current_bundle()
     changeset = Settings.change_bundle(data)
 
     conn
@@ -13,7 +13,7 @@ defmodule SiwappWeb.SettingsController do
   end
 
   def update(conn, %{"setting_bundle" => attrs}) do
-    case Settings.apply_user_settings(attrs) do
+    case Settings.apply_user_bundle(attrs) do
       {:ok, changeset} ->
         conn
         |> assign(:changeset, changeset)
@@ -21,7 +21,7 @@ defmodule SiwappWeb.SettingsController do
         |> render("edit.html")
 
       {:error, changeset} ->
-        render(conn, "edit.html", changeset: %{changeset | action: :insert})
+        render(conn, "edit.html", changeset: changeset)
     end
   end
 end

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -15,7 +15,6 @@ defmodule Siwapp.InvoiceTest do
     {:ok, tax1} = Commons.create_tax(%{name: "VAT", value: 21, default: true})
     {:ok, tax2} = Commons.create_tax(%{name: "RETENTION", value: -15})
     settings_fixture()
-
     %{series_id: series.id, taxes: [tax1, tax2]}
   end
 
@@ -170,7 +169,7 @@ defmodule Siwapp.InvoiceTest do
     test "Due date is today + 'Days to due' value set in Settings if none is provided", %{
       today: today
     } do
-      Settings.apply_user_settings(%{"days_to_due" => "5"})
+      Settings.update({:days_to_due, "5"})
 
       assert invoice_fixture().due_date == Date.add(today, 5)
     end

--- a/test/support/fixtures/settings_fixtures.ex
+++ b/test/support/fixtures/settings_fixtures.ex
@@ -25,6 +25,6 @@ defmodule Siwapp.SettingsFixtures do
     |> valid_settings_attributes()
     |> Enum.each(&Settings.create/1)
 
-    Settings.prepare_data()
+    Settings.current_bundle()
   end
 end


### PR DESCRIPTION
fixes #274 

En el context de Settings tenemos en API
- create({key, value}) - que sólo usamos en seeds
- update({key, value}) - que es la que va a modificar nuestros settings target que son siempre preexistentes en db pues se inicializan en seeds y no se borran
- get(key) - struct del setting asociado a key y si no existe nil
- value(key) - valor del setting asociado a key y si no existe nil
- current_bundle - devuelve el struct de los settings en db
- change_bundle(SettingBundle, attrs) - changeset del SettingBundle con los parámetros dados por attrs
- apply_user_bundle(attrs) - guarda en base de datos los settings definidos en el mapa de attrs si el changeset de ese SettingBundle es válido. Da feedback del resultado y devuelve changeset del bundle.