### PR TITLE
invoices summary section [v1]

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -81,6 +81,10 @@ p.control.has-dropdown {
   margin-top: 0.5rem;
 }
 
+.card.card-header:hover {
+  background-color: #fafafa;
+}
+
 @media screen and (max-width: 600px) {
   .columns.is-multiline-mobile {
     display: flex;

--- a/lib/siwapp/invoices/statistics.ex
+++ b/lib/siwapp/invoices/statistics.ex
@@ -17,6 +17,8 @@ defmodule Siwapp.Invoices.Statistics do
     |> Enum.map(&{&1.issue_date, &1.gross_amount})
   end
 
+  def get_accumulated_amount(invoices \\ Invoices.list()), do: sum_amounts(invoices)
+
   # We need this function so we have data (with amount = 0) for those days we have no invoices.
   # First, we create a series of graphic points with amounts of 0 for the given 'days'. Then we join
   # them with the actual data from database.
@@ -41,7 +43,7 @@ defmodule Siwapp.Invoices.Statistics do
   end
 
   @spec sum_amounts([map()]) :: non_neg_integer()
-  defp sum_amounts(day) do
-    Enum.sum(Enum.map(day, & &1.gross_amount))
+  defp sum_amounts(invoices) do
+    Enum.sum(Enum.map(invoices, & &1.gross_amount))
   end
 end

--- a/lib/siwapp/invoices/statistics.ex
+++ b/lib/siwapp/invoices/statistics.ex
@@ -13,7 +13,7 @@ defmodule Siwapp.Invoices.Statistics do
     invoices
     |> Enum.map(&Map.take(&1, [:issue_date, :gross_amount]))
     |> accumulate_amounts()
-    |> set_time_scale(31)
+    |> set_time_scale(30)
     |> Enum.map(&{&1.issue_date, &1.gross_amount})
   end
 

--- a/lib/siwapp/invoices/statistics.ex
+++ b/lib/siwapp/invoices/statistics.ex
@@ -6,15 +6,14 @@ defmodule Siwapp.Invoices.Statistics do
 
   @doc """
   Returns a list of tuples, each containing the accumulated amount of money from all the invoices
-  per day. You can pass a param 'days' with the time scale you want this data to be scaled to (31
-  by default).
+  per day, for the given selection of 'invoices'.
   """
-  @spec get_data(pos_integer()) :: [tuple()]
-  def get_data(days \\ 31) do
-    Invoices.list()
+  @spec get_data_for_a_month(pos_integer()) :: [tuple()]
+  def get_data_for_a_month(invoices \\ Invoices.list()) do
+    invoices
     |> Enum.map(&Map.take(&1, [:issue_date, :gross_amount]))
     |> accumulate_amounts()
-    |> set_time_scale(days)
+    |> set_time_scale(31)
     |> Enum.map(&{&1.issue_date, &1.gross_amount})
   end
 

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -3,7 +3,6 @@ defmodule SiwappWeb.InvoicesLive.Index do
   use SiwappWeb, :live_view
 
   alias Siwapp.Invoices
-  alias Phoenix.LiveView.JS
   alias SiwappWeb.GraphicHelpers
 
   def mount(_params, _session, socket) do
@@ -12,6 +11,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
      |> assign(:page, 0)
      |> assign(:invoices, Invoices.scroll_listing(0))
      |> assign(:checked, MapSet.new())
+     |> assign(:summary_section, set_summary(:closed))
      |> assign(:page_title, "Invoices")}
   end
 
@@ -46,6 +46,14 @@ defmodule SiwappWeb.InvoicesLive.Index do
     end
   end
 
+  def handle_event("change-summary-state", _params, socket) do
+    if socket.assigns.summary_section.state == "opened" do
+      {:noreply, assign(socket, :summary_section, set_summary(:closed))}
+    else
+      {:noreply, assign(socket, :summary_section, set_summary(:opened))}
+    end
+  end
+
   defp update_checked(%{"id" => "0", "value" => "on"}, socket) do
     socket.assigns.invoices
     |> MapSet.new(& &1.id)
@@ -71,4 +79,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     |> Enum.map(&GraphicHelpers.date_to_naive_type/1)
     |> GraphicHelpers.line_plot()
   end
+
+  defp set_summary(:opened), do: %{state: "opened", visibility: "is-block", icon: "fa-angle-up"}
+  defp set_summary(:closed), do: %{state: "closed", visibility: "is-hidden", icon: "fa-angle-down"}
 end

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -74,9 +74,9 @@ defmodule SiwappWeb.InvoicesLive.Index do
     |> MapSet.delete(0)
   end
 
-  defp summary_chart() do
-    Invoices.Statistics.get_data()
-    |> Enum.map(&GraphicHelpers.date_to_naive_type/1)
+  defp summary_chart(invoices) do
+    Invoices.Statistics.get_data_for_a_month(invoices)
+    |> Enum.map(fn {date, amount} -> {NaiveDateTime.new!(date, ~T[00:00:00]), amount} end)
     |> GraphicHelpers.line_plot()
   end
 

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -14,21 +14,6 @@ defmodule SiwappWeb.InvoicesLive.Index do
      |> assign(:page_title, "Invoices")}
   end
 
-  def handle_event("load-more", _, %{id: "home"} = socket) do
-    %{
-      page: page,
-      invoices: invoices
-    } = socket.assigns
-
-    {
-      :noreply,
-      assign(socket,
-        invoices: invoices ++ Invoices.list_past_due(page + 1),
-        page: page + 1
-      )
-    }
-  end
-
   def handle_event("load-more", _, socket) do
     %{
       page: page,

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -10,7 +10,8 @@ defmodule SiwappWeb.InvoicesLive.Index do
      socket
      |> assign(:page, 0)
      |> assign(:invoices, Invoices.list_past_due(0))
-     |> assign(:checked, MapSet.new())}
+     |> assign(:checked, MapSet.new())
+     |> assign(:page_title, "Invoices")}
   end
 
   def mount(_params, _session, socket) do
@@ -18,7 +19,8 @@ defmodule SiwappWeb.InvoicesLive.Index do
      socket
      |> assign(:page, 0)
      |> assign(:invoices, Invoices.scroll_listing(0))
-     |> assign(:checked, MapSet.new())}
+     |> assign(:checked, MapSet.new())
+     |> assign(:page_title, "Invoices")}
   end
 
   def handle_event("load-more", _, %{id: "home"} = socket) do

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -3,6 +3,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
   use SiwappWeb, :live_view
 
   alias Siwapp.Invoices
+  alias Phoenix.LiveView.JS
 
   def mount(_params, _session, socket) do
     {:ok,

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -81,5 +81,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
   end
 
   defp set_summary(:opened), do: %{state: "opened", visibility: "is-block", icon: "fa-angle-up"}
-  defp set_summary(:closed), do: %{state: "closed", visibility: "is-hidden", icon: "fa-angle-down"}
+
+  defp set_summary(:closed),
+    do: %{state: "closed", visibility: "is-hidden", icon: "fa-angle-down"}
 end

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -4,6 +4,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
 
   alias Siwapp.Invoices
   alias Phoenix.LiveView.JS
+  alias SiwappWeb.GraphicHelpers
 
   def mount(_params, _session, socket) do
     {:ok,
@@ -63,5 +64,11 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket.assigns.checked
     |> MapSet.delete(String.to_integer(id))
     |> MapSet.delete(0)
+  end
+
+  defp summary_chart() do
+    Invoices.Statistics.get_data()
+    |> Enum.map(&GraphicHelpers.date_to_naive_type/1)
+    |> GraphicHelpers.line_plot()
   end
 end

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -3,16 +3,6 @@ defmodule SiwappWeb.InvoicesLive.Index do
   use SiwappWeb, :live_view
 
   alias Siwapp.Invoices
-  alias SiwappWeb.PageView
-
-  def mount(_params, _session, %{id: "home"} = socket) do
-    {:ok,
-     socket
-     |> assign(:page, 0)
-     |> assign(:invoices, Invoices.list_past_due(0))
-     |> assign(:checked, MapSet.new())
-     |> assign(:page_title, "Invoices")}
-  end
 
   def mount(_params, _session, socket) do
     {:ok,

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -32,10 +32,7 @@
   <div id="summary-card" class="card">
     <div class="card-content">
       <div class="content">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis mauris.
-        <a href="#">@bulmaio</a>. <a href="#">#css</a> <a href="#">#responsive</a>
-        <br>
-        <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
+        <%= SiwappWeb.PageLive.Index.dashboard_chart() %>
       </div>
     </div>
   </div>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -17,9 +17,9 @@
 <div class="mb-5">
   <div class="is-flex is-justify-content-space-between">
     <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
-    <header class="card card-header" phx-click="change-summary-state">
+    <header class="card card-header is-clickable is-unselectable" phx-click="change-summary-state">
       <span class="card-header-title is-size-4">
-        $ 258,481.00
+        <%= SiwappWeb.PageView.set_currency(Invoices.Statistics.get_accumulated_amount(), nil) %>
       </span>
       <button class="card-header-icon" aria-label="more options">
         <span class="icon">

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -16,59 +16,6 @@
 
 <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
 
-<table class="table is-fullwidth is-striped is-bordered is-hoverable">
-  <thead>
-    <tr>
-      <th title=""><input type="checkbox" checked={Enum.member?(@checked, 0)} phx-click="click_checkbox" phx-value-id="0"></th>
-      <th title="Reference">Reference</th>
-      <th title="Customer">Customer Name</th>
-      <th title="Date">Date</th>
-      <th title="Sent">Sent</th>
-      <th title="Status">Status</th>
-      <th title="Pending">Pending</th>
-      <th title="Total">Total</th>
-    </tr>
-  </thead>
+<%= render(SiwappWeb.PageView, "invoices_table.html", invoices: @invoices, checked: @checked) %>
 
-  <tbody>
-    <%= for invoice <- @invoices do %>
-      <tr phx-click="redirect" phx-value-id={invoice.id} class="is-clickable">
-        <td><input type="checkbox" phx-click="click_checkbox" checked={Enum.member?(@checked, invoice.id)} phx-value-id={invoice.id}></td>
-        <td><%= "#{invoice.series.code}-#{invoice.number}" %></td>
-        <td><%= invoice.name %></td>
-        <td><%= invoice.issue_date %></td>
-
-        <%= if invoice.sent_by_email do%>
-          <td class="icon has-text-success table-icon"><i class="fas fa-check"></i></td>
-        <% else %>
-          <td class="icon has-text-danger table-icon"><i class="fas fa-times"></i></td>
-        <% end %>
-
-        <%= case Invoices.status(invoice) do %>
-          <% :draft -> %>
-            <td class="table-span"><span class="tag is-info">Draft</span></td>
-            <td></td>
-
-          <% :failed -> %>
-            <td class="table-span"><span class="tag is-danger">Failed</span></td>
-            <td></td>
-
-          <% :paid -> %>
-            <td class="table-span"><span class="tag is-success">Paid</span></td>
-            <td></td>
-
-          <% :pending -> %>
-            <td class="table-span"><span class="tag is-warning">Pending</span></td>
-            <td><%= PageView.set_currency(invoice.gross_amount, invoice.currency) %></td>
-
-          <% :past_due -> %>
-            <td class="table-span"><span class="tag is-danger">Past_Due</span></td>
-            <td><%= PageView.set_currency(invoice.gross_amount, invoice.currency) %></td>
-        <% end %>
-
-        <td><%= PageView.set_currency(invoice.gross_amount, invoice.currency) %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
 <div id="infinite-scroll" phx-hook="InfiniteScroll" data-page={@page}></div>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -14,6 +14,8 @@
   </div>
 </nav>
 
+<h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
+
 <table class="table is-fullwidth is-striped is-bordered is-hoverable">
   <thead>
     <tr>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -32,7 +32,7 @@
   <div id="summary-card" class={"card #{@summary_section.visibility}"}>
     <div class="card-content">
       <div class="content">
-        <%= summary_chart() %>
+        <%= summary_chart(@invoices) %>
       </div>
     </div>
   </div>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -17,19 +17,19 @@
 <div class="mb-5">
   <div class="is-flex is-justify-content-space-between">
     <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
-    <header class="card card-header">
+    <header class="card card-header" phx-click="change-summary-state">
       <span class="card-header-title is-size-4">
         $ 258,481.00
       </span>
-      <button class="card-header-icon" aria-label="more options" phx-click={JS.toggle(to: "#summary-card")}>
+      <button class="card-header-icon" aria-label="more options">
         <span class="icon">
-          <i class="fas fa-angle-down" aria-hidden="true"></i>
+          <i class={"fas #{@summary_section.icon}"} aria-hidden="true"></i>
         </span>
       </button>
     </header>
   </div>
 
-  <div id="summary-card" class="card">
+  <div id="summary-card" class={"card #{@summary_section.visibility}"}>
     <div class="card-content">
       <div class="content">
         <%= summary_chart() %>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -19,7 +19,7 @@
     <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
     <header class="card card-header is-clickable is-unselectable" phx-click="change-summary-state">
       <span class="card-header-title is-size-4">
-        <%= SiwappWeb.PageView.set_currency(Invoices.Statistics.get_accumulated_amount(), nil) %>
+        <%= SiwappWeb.PageView.set_currency(Invoices.Statistics.get_accumulated_amount(@invoices), nil) %>
       </span>
       <button class="card-header-icon" aria-label="more options">
         <span class="icon">

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -14,7 +14,30 @@
   </div>
 </nav>
 
-<h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
+<div class="invoice-index-header is-flex is-justify-content-space-between">
+  <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
+  <header class="card card-header">
+    <span class="card-header-title is-size-4">
+      $ 258,481.00
+    </span>
+    <button class="card-header-icon" aria-label="more options">
+      <span class="icon">
+        <i class="fas fa-angle-down" aria-hidden="true"></i>
+      </span>
+    </button>
+  </header>
+</div>
+
+<div class="card mb-5">
+  <div class="card-content">
+    <div class="content">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis mauris.
+      <a href="#">@bulmaio</a>. <a href="#">#css</a> <a href="#">#responsive</a>
+      <br>
+      <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
+    </div>
+  </div>
+</div>
 
 <%= render(SiwappWeb.PageView, "invoices_table.html", invoices: @invoices, checked: @checked) %>
 

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -14,27 +14,29 @@
   </div>
 </nav>
 
-<div class="invoice-index-header is-flex is-justify-content-space-between">
-  <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
-  <header class="card card-header">
-    <span class="card-header-title is-size-4">
-      $ 258,481.00
-    </span>
-    <button class="card-header-icon" aria-label="more options">
-      <span class="icon">
-        <i class="fas fa-angle-down" aria-hidden="true"></i>
+<div class="mb-5">
+  <div class="is-flex is-justify-content-space-between">
+    <h1><%= @page_title %><span class="subtitle is-5"> (<%= length(@invoices) %> Found)</span></h1>
+    <header class="card card-header">
+      <span class="card-header-title is-size-4">
+        $ 258,481.00
       </span>
-    </button>
-  </header>
-</div>
+      <button class="card-header-icon" aria-label="more options" phx-click={JS.toggle(to: "#summary-card")}>
+        <span class="icon">
+          <i class="fas fa-angle-down" aria-hidden="true"></i>
+        </span>
+      </button>
+    </header>
+  </div>
 
-<div class="card mb-5">
-  <div class="card-content">
-    <div class="content">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis mauris.
-      <a href="#">@bulmaio</a>. <a href="#">#css</a> <a href="#">#responsive</a>
-      <br>
-      <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
+  <div id="summary-card" class="card">
+    <div class="card-content">
+      <div class="content">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus nec iaculis mauris.
+        <a href="#">@bulmaio</a>. <a href="#">#css</a> <a href="#">#responsive</a>
+        <br>
+        <time datetime="2016-1-1">11:09 PM - 1 Jan 2016</time>
+      </div>
     </div>
   </div>
 </div>

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -32,7 +32,7 @@
   <div id="summary-card" class="card">
     <div class="card-content">
       <div class="content">
-        <%= SiwappWeb.PageLive.Index.dashboard_chart() %>
+        <%= summary_chart() %>
       </div>
     </div>
   </div>

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -18,8 +18,8 @@ defmodule SiwappWeb.PageLive.Index do
   """
   @spec dashboard_chart :: {:safe, [...]}
   def dashboard_chart do
-    Invoices.Statistics.get_data()
-    |> Enum.map(&GraphicHelpers.date_to_naive_type/1)
+    Invoices.Statistics.get_data_for_a_month()
+    |> Enum.map(fn {date, amount} -> {NaiveDateTime.new!(date, ~T[00:00:00]), amount} end)
     |> GraphicHelpers.line_plot()
   end
 

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -37,5 +37,4 @@ defmodule SiwappWeb.PageLive.Index do
       )
     }
   end
-
 end

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -19,7 +19,7 @@ defmodule SiwappWeb.PageLive.Index do
   @spec dashboard_chart :: {:safe, [...]}
   def dashboard_chart do
     Invoices.Statistics.get_data()
-    |> Enum.map(&date_to_naive_type/1)
+    |> Enum.map(&GraphicHelpers.date_to_naive_type/1)
     |> GraphicHelpers.line_plot()
   end
 
@@ -38,9 +38,4 @@ defmodule SiwappWeb.PageLive.Index do
     }
   end
 
-  # This is necessary because Contex.DateScale only accepts DateTime or NaiveDateTime types.
-  @spec date_to_naive_type({Date.t(), integer()}) :: {NaiveDateTime.t(), integer()}
-  defp date_to_naive_type({date, amount}) do
-    {NaiveDateTime.new!(date, ~T[00:00:00]), amount}
-  end
 end

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -6,6 +6,13 @@ defmodule SiwappWeb.PageLive.Index do
   alias Siwapp.Invoices
   alias SiwappWeb.GraphicHelpers
 
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page, 0)
+     |> assign(:invoices, Invoices.list_past_due(0))}
+  end
+
   @doc """
   Creates the dashboard chart with information about invoices (amounts of money per day).
   """
@@ -14,6 +21,21 @@ defmodule SiwappWeb.PageLive.Index do
     Invoices.Statistics.get_data()
     |> Enum.map(&date_to_naive_type/1)
     |> GraphicHelpers.line_plot()
+  end
+
+  def handle_event("load-more", _, socket) do
+    %{
+      page: page,
+      invoices: invoices
+    } = socket.assigns
+
+    {
+      :noreply,
+      assign(socket,
+        invoices: invoices ++ Invoices.list_past_due(page + 1),
+        page: page + 1
+      )
+    }
   end
 
   # This is necessary because Contex.DateScale only accepts DateTime or NaiveDateTime types.

--- a/lib/siwapp_web/live/page_live/index.html.heex
+++ b/lib/siwapp_web/live/page_live/index.html.heex
@@ -2,4 +2,4 @@
 
 <h1>Past due invoices</h1>
 
-<%= live_render(@socket, SiwappWeb.InvoicesLive.Index, id: "home") %>
+<%= render(SiwappWeb.PageView, "invoices_table.html", invoices: Invoices.list_past_due(0), checked: []) %>

--- a/lib/siwapp_web/live/page_live/index.html.heex
+++ b/lib/siwapp_web/live/page_live/index.html.heex
@@ -2,4 +2,6 @@
 
 <h1>Past due invoices</h1>
 
-<%= render(SiwappWeb.PageView, "invoices_table.html", invoices: Invoices.list_past_due(0), checked: []) %>
+<%= render(SiwappWeb.PageView, "invoices_table.html", invoices: @invoices, checked: []) %>
+
+<div id="infinite-scroll" phx-hook="InfiniteScroll" data-page={@page}></div>

--- a/lib/siwapp_web/templates/page/invoices_table.html.heex
+++ b/lib/siwapp_web/templates/page/invoices_table.html.heex
@@ -1,0 +1,59 @@
+<table class="table is-fullwidth is-striped is-bordered is-hoverable">
+  <thead>
+    <tr>
+      <%= if @checked != [] do %>
+        <th title=""><input type="checkbox" checked={Enum.member?(@checked, 0)} phx-click="click_checkbox" phx-value-id="0"></th>
+      <% end %>
+      <th title="Reference">Reference</th>
+      <th title="Customer">Customer Name</th>
+      <th title="Date">Date</th>
+      <th title="Sent">Sent</th>
+      <th title="Status">Status</th>
+      <th title="Pending">Pending</th>
+      <th title="Total">Total</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <%= for invoice <- @invoices do %>
+      <tr phx-click="redirect" phx-value-id={invoice.id} class="is-clickable">
+        <%= if @checked != [] do %>
+          <td><input type="checkbox" phx-click="click_checkbox" checked={Enum.member?(@checked, invoice.id)} phx-value-id={invoice.id}></td>
+        <% end %>
+        <td><%=invoice.series_id%></td>
+        <td><%= invoice.name %></td>
+        <td><%= invoice.issue_date %></td>
+
+        <%= if invoice.sent_by_email do%>
+          <td class="icon has-text-success table-icon"><i class="fas fa-check"></i></td>
+        <% else %>
+          <td class="icon has-text-danger table-icon"><i class="fas fa-times"></i></td>
+        <% end %>
+
+        <%= case Siwapp.Invoices.status(invoice) do %>
+          <% :draft -> %>
+            <td class="table-span"><span class="tag is-info">Draft</span></td>
+            <td></td>
+
+          <% :failed -> %>
+            <td class="table-span"><span class="tag is-danger">Failed</span></td>
+            <td></td>
+
+          <% :paid -> %>
+            <td class="table-span"><span class="tag is-success">Paid</span></td>
+            <td></td>
+
+          <% :pending -> %>
+            <td class="table-span"><span class="tag is-warning">Pending</span></td>
+            <td><%= set_currency(invoice.gross_amount, invoice.currency) %></td>
+
+          <% :past_due -> %>
+            <td class="table-span"><span class="tag is-danger">Past_Due</span></td>
+            <td><%= set_currency(invoice.gross_amount, invoice.currency) %></td>
+        <% end %>
+
+        <td><%= set_currency(invoice.gross_amount, invoice.currency) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/lib/siwapp_web/views/graphic_helpers.ex
+++ b/lib/siwapp_web/views/graphic_helpers.ex
@@ -23,5 +23,4 @@ defmodule SiwappWeb.GraphicHelpers do
     |> Map.put(:margins, margins)
     |> Plot.to_svg()
   end
-
 end

--- a/lib/siwapp_web/views/graphic_helpers.ex
+++ b/lib/siwapp_web/views/graphic_helpers.ex
@@ -15,9 +15,18 @@ defmodule SiwappWeb.GraphicHelpers do
       smoothed: false
     ]
 
+    margins = %{left: 35, right: 15, top: 10, bottom: 20}
+
     data
     |> Dataset.new()
-    |> Plot.new(LinePlot, 500, 200, options)
+    |> Plot.new(LinePlot, 500, 150, options)
+    |> Map.put(:margins, margins)
     |> Plot.to_svg()
+  end
+
+  # This is necessary because Contex.DateScale only accepts DateTime or NaiveDateTime types.
+  @spec date_to_naive_type({Date.t(), integer()}) :: {NaiveDateTime.t(), integer()}
+  def date_to_naive_type({date, amount}) do
+    {NaiveDateTime.new!(date, ~T[00:00:00]), amount}
   end
 end

--- a/lib/siwapp_web/views/graphic_helpers.ex
+++ b/lib/siwapp_web/views/graphic_helpers.ex
@@ -24,9 +24,4 @@ defmodule SiwappWeb.GraphicHelpers do
     |> Plot.to_svg()
   end
 
-  # This is necessary because Contex.DateScale only accepts DateTime or NaiveDateTime types.
-  @spec date_to_naive_type({Date.t(), integer()}) :: {NaiveDateTime.t(), integer()}
-  def date_to_naive_type({date, amount}) do
-    {NaiveDateTime.new!(date, ~T[00:00:00]), amount}
-  end
 end

--- a/lib/siwapp_web/views/graphic_helpers.ex
+++ b/lib/siwapp_web/views/graphic_helpers.ex
@@ -12,10 +12,11 @@ defmodule SiwappWeb.GraphicHelpers do
     options = [
       data_labels: false,
       default_style: false,
+      stroke_width: 1,
       smoothed: false
     ]
 
-    margins = %{left: 35, right: 15, top: 10, bottom: 20}
+    margins = %{left: 45, right: 15, top: 10, bottom: 20}
 
     data
     |> Dataset.new()


### PR DESCRIPTION
related to #280, but this doesn't close it

PR inicial de la sección de la gráfica en el índex de invoices. Se ha hecho:
- Mover el html de la tabla de Invoices a invoices_table.html.heex, y lo reutilizan tanto el index de InvoicesLive como la página Home
- En el index de Invoices, un header: a la izquierda el número de invoices listadas entre paréntesis y a la derecha el botóncito con el Gross amount acumulado, que si le das te aparece la gráfica según las invoices que estén el assign 'invoices'.
- Para abrir y cerrar la gráfica se han utilizado assigns del socket y no JS.toggle, ya que así podía también cambiar el icono de ^ que indica si está abierto o cerrado. Si pensáis que es mejor con JS.toggle, podría intentar adaptarlo.

![githubgif](https://user-images.githubusercontent.com/49884623/153183504-41a3ef32-83f3-4b21-b755-5e3494bf163a.gif)

Por ahora sólo esta en invoices y trabaja sólo con una currency. En próximos PRs:
- Que aparezcan las distintas currencies en el header y en la gráfica estén sumadas
- Incluido en recurrir invoices