### PR TITLE
Nurietzsche/customer index

### DIFF
--- a/lib/siwapp/customers.ex
+++ b/lib/siwapp/customers.ex
@@ -5,6 +5,7 @@ defmodule Siwapp.Customers do
   import Ecto.Query
 
   alias Siwapp.Customers.Customer
+  alias Siwapp.Invoices.{Invoice, InvoiceQuery}
   alias Siwapp.Query
   alias Siwapp.Repo
 
@@ -94,6 +95,37 @@ defmodule Siwapp.Customers do
 
   def change(%Customer{} = customer, attrs \\ %{}) do
     Customer.changeset(customer, attrs)
+  end
+
+  def money(customer_id, type) do
+    currency =
+      case currencies(customer_id) do
+        [nil] -> nil
+        [currency] -> String.to_existing_atom(currency)
+        _ -> nil
+      end
+
+    {amount(customer_id, type), currency}
+  end
+
+  defp currencies(customer_id) do
+    Invoice
+    |> InvoiceQuery.currencies_for_customer(customer_id)
+    |> Repo.all()
+  end
+
+  def amount(customer_id, :due) do
+    case {amount(customer_id, :total), amount(customer_id, :paid)} do
+      {total, nil} -> total || 0
+      {nil, paid} -> -paid
+      {total, paid} -> total - paid
+    end
+  end
+
+  def amount(customer_id, type) do
+    Invoice
+    |> InvoiceQuery.amount_for_customer(customer_id, type)
+    |> Repo.one() || 0
   end
 
   @spec get_by_hash_id(binary, binary) :: Customer.t() | nil

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -33,7 +33,7 @@ defmodule Siwapp.Invoices do
 
   @doc """
   Gets a list of the invoices by giving a list of tuples with {key, value}
-  where the key is an atom
+  where the key is an atom. If second argument provided, preloads this.
   """
 
   @spec list_by([{atom(), any()}]) :: list()
@@ -41,6 +41,15 @@ defmodule Siwapp.Invoices do
     Enum.reduce(query_list, Invoice, fn {field, value}, acc_query ->
       InvoiceQuery.list_by_query(acc_query, field, value)
     end)
+    |> Repo.all()
+  end
+
+  @spec list_by([{atom(), any()}], atom) :: list()
+  def list_by(query_list, assoc) do
+    Enum.reduce(query_list, Invoice, fn {field, value}, acc_query ->
+      InvoiceQuery.list_by_query(acc_query, field, value)
+    end)
+    |> Query.list_preload(assoc)
     |> Repo.all()
   end
 

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -43,6 +43,34 @@ defmodule Siwapp.Invoices.InvoiceQuery do
     |> limit(1)
   end
 
+  def amount_for_customer(query, customer_id, :total) do
+    query
+    |> where(customer_id: ^customer_id)
+    |> where(draft: false)
+    |> where(failed: false)
+    |> select([i], sum(i.gross_amount))
+  end
+
+  def amount_for_customer(query, customer_id, :paid) do
+    query
+    |> where(customer_id: ^customer_id)
+    |> where(draft: false)
+    |> where(failed: false)
+    |> select([i], sum(i.paid_amount))
+  end
+
+  def invoices_for_customer(query, customer_id) do
+    query
+    |> where(customer_id: ^customer_id)
+  end
+
+  def currencies_for_customer(query, customer_id) do
+    query
+    |> where(customer_id: ^customer_id)
+    |> group_by([i], i.currency)
+    |> select([i], i.currency)
+  end
+
   @doc """
   Gets a query on the invoices that match with the params
   """

--- a/lib/siwapp_web/live/customer_live/index.ex
+++ b/lib/siwapp_web/live/customer_live/index.ex
@@ -2,6 +2,7 @@ defmodule SiwappWeb.CustomerLive.Index do
   use SiwappWeb, :live_view
 
   alias Siwapp.Customers
+  alias SiwappWeb.PageView
 
   @moduledoc """
 
@@ -33,5 +34,12 @@ defmodule SiwappWeb.CustomerLive.Index do
 
   def handle_event("edit", %{"id" => id}, socket) do
     {:noreply, push_redirect(socket, to: Routes.customer_edit_path(socket, :edit, id))}
+  end
+
+  def money(customer_id, type) do
+    case Customers.money(customer_id, type) do
+      {amount, nil} -> amount
+      {amount, currency} -> PageView.set_currency(amount, currency)
+    end
   end
 end

--- a/lib/siwapp_web/live/customer_live/index.html.heex
+++ b/lib/siwapp_web/live/customer_live/index.html.heex
@@ -15,11 +15,9 @@
       <tr phx-click="edit" phx-value-id={customer.id} class="is-clickable">
         <td class="no-wrap"><%= customer.name%></td>
         <td class="no-wrap"><%= customer.identification%></td>
-        <!-- my suggestion is creating total and due as helper functions receiving customer.invoices -->
-        <td class="text-right">DUE</td>
-        <td class="text-right">TOTAL</td>
-        <td class="text-center"><%= live_redirect " ", class: "icon fas fa-list", to: Routes.customer_edit_path(@socket, :edit, customer.id) %></td>
-        <!-- we will change last redirection to invoices for customer -->
+        <td class="text-right"><%= money(customer.id, :due)%></td>
+        <td class="text-right"><%= money(customer.id, :total)%></td>
+        <td class="text-center"><%= live_redirect " ", class: "icon fas fa-list", to: Routes.customer_show_path(@socket, :show, customer.id) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/lib/siwapp_web/live/customer_live/show.ex
+++ b/lib/siwapp_web/live/customer_live/show.ex
@@ -8,11 +8,18 @@ defmodule SiwappWeb.CustomerLive.Show do
     {:ok, socket}
   end
 
+  def render(assigns) do
+    ~H"""
+      <h1>Invoices for <%= @customer.name %></h1>
+      <%= live_render(@socket, SiwappWeb.InvoicesLive.Index, id: "show_invoices", session: %{ "customer_id" => @customer.id }) %>
+    """
+  end
+
   def handle_params(params, _url, socket) do
     {:noreply, apply_action(socket, socket.assigns.live_action, params)}
   end
 
-  def apply_action(socket, :show, %{ "id" => customer_id }) do
+  def apply_action(socket, :show, %{"id" => customer_id}) do
     socket
     |> assign(:customer, Customers.get(customer_id))
   end

--- a/lib/siwapp_web/live/customer_live/show.ex
+++ b/lib/siwapp_web/live/customer_live/show.ex
@@ -1,0 +1,19 @@
+defmodule SiwappWeb.CustomerLive.Show do
+  @moduledoc false
+  use SiwappWeb, :live_view
+
+  alias Siwapp.Customers
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(params, _url, socket) do
+    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  end
+
+  def apply_action(socket, :show, %{ "id" => customer_id }) do
+    socket
+    |> assign(:customer, Customers.get(customer_id))
+  end
+end

--- a/lib/siwapp_web/live/customer_live/show.html.heex
+++ b/lib/siwapp_web/live/customer_live/show.html.heex
@@ -1,2 +1,0 @@
-<h1>Invoices for <%= @customer.name %></h1>
-<%= live_render(@socket, SiwappWeb.InvoicesLive.Index, id: "show_invoices", session: %{ "customer_id" => @customer.id }) %>

--- a/lib/siwapp_web/live/customer_live/show.html.heex
+++ b/lib/siwapp_web/live/customer_live/show.html.heex
@@ -1,0 +1,2 @@
+<h1>Invoices for <%= @customer.name %></h1>
+<%= live_render(@socket, SiwappWeb.InvoicesLive.Index, id: "show_invoices", session: %{ "customer_id" => @customer.id }) %>

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -13,6 +13,14 @@ defmodule SiwappWeb.InvoicesLive.Index do
      |> assign(:checked, MapSet.new())}
   end
 
+  def mount(_params, %{"customer_id" => customer_id}, %{id: "show_invoices"} = socket) do
+    {:ok,
+     socket
+     |> assign(:page, 0)
+     |> assign(:invoices, Invoices.list_by([{:customer_id, customer_id}], :series))
+     |> assign(:checked, MapSet.new())}
+  end
+
   def mount(_params, _session, socket) do
     {:ok,
      socket

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -127,6 +127,7 @@ defmodule SiwappWeb.Router do
 
       live "/customers/new", CustomerLive.Edit, :new
       live "/customers/:id/edit", CustomerLive.Edit, :edit
+      live "/customers/:id/invoices", CustomerLive.Show, :show
       live "/customers/", CustomerLive.Index, :index
 
       live "/templates", TemplatesLive.Index, :index


### PR DESCRIPTION
fixes #264 

DINERO
Como véis, está pensado para que si hay más de una divisa o ninguna por cliente, se renderice directamente la cantidad de dinero. Las cantidades se calculan con querys a db. Cambié a esta opción, en vez de hacer preload y luego sumar con las invoices cargadas porque creo que eso debe ser más costoso, no sé.

SHOW
La vista de show es live para que se implemente más adelante el botón que añade la gráfica más tarde. Esta LV usa el index de invoices.