### PR TITLE
currencies

### DIFF
--- a/lib/siwapp/invoice_helper.ex
+++ b/lib/siwapp/invoice_helper.ex
@@ -22,6 +22,14 @@ defmodule Siwapp.InvoiceHelper do
     end
   end
 
+  def assign_currency(changeset) do
+    if get_field(changeset, :currency) do
+      changeset
+    else
+      put_change(changeset, :currency, Siwapp.Settings.value(:currency))
+    end
+  end
+
   @doc """
   Performs the totals calculations for net_amount, taxes_amounts and gross_amount fields.
   """

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -149,12 +149,9 @@ defmodule Siwapp.Invoices do
     end
   end
 
-  defp due_date_status(due_date) do
-    if Date.diff(due_date, Date.utc_today()) > 0 do
-      :pending
-    else
-      :past_due
-    end
+  def list_currencies do
+    default_currency = Siwapp.Settings.value(:currency)
+    Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
   end
 
   @spec next_number_in_series(pos_integer()) :: integer
@@ -166,6 +163,23 @@ defmodule Siwapp.Invoices do
       invoice -> invoice.number + 1
     end
   end
+
+  defp due_date_status(due_date) do
+    if Date.diff(due_date, Date.utc_today()) > 0 do
+      :pending
+    else
+      :past_due
+    end
+  end
+
+  defp all_currencies do
+    Money.Currency.all()
+    |> Map.keys()
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.sort()
+  end
+
+  defp primary_currencies, do: ["USD", "EUR", "GBP"]
 
   @doc """
   Gets an item by id

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -150,8 +150,9 @@ defmodule Siwapp.Invoices do
   end
 
   def list_currencies do
-    default_currency = Siwapp.Settings.value(:currency)
-    Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
+    Money.Currency.all()
+    |> Map.keys()
+    |> Enum.sort()
   end
 
   @spec next_number_in_series(pos_integer()) :: integer
@@ -171,15 +172,6 @@ defmodule Siwapp.Invoices do
       :past_due
     end
   end
-
-  defp all_currencies do
-    Money.Currency.all()
-    |> Map.keys()
-    |> Enum.map(&Atom.to_string/1)
-    |> Enum.sort()
-  end
-
-  defp primary_currencies, do: ["USD", "EUR", "GBP"]
 
   @doc """
   Gets an item by id

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -93,7 +93,7 @@ defmodule Siwapp.Invoices.Invoice do
     field :due_date, :date
     field :failed, :boolean, default: false
     field :deleted_number, :integer
-    field :currency, :string
+    field :currency, :string, autogenerate: {Siwapp.Settings, :value, [:currency]}
     field :invoicing_address, :string
     field :shipping_address, :string
     field :notes, :string

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -127,7 +127,7 @@ defmodule Siwapp.Invoices.Invoice do
     |> validate_length(:identification, max: 50)
     |> validate_length(:email, max: 100)
     |> validate_length(:contact_person, max: 100)
-    |> validate_length(:currency, max: 100)
+    |> validate_length(:currency, max: 3)
     |> calculate()
   end
 

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -93,7 +93,7 @@ defmodule Siwapp.Invoices.Invoice do
     field :due_date, :date
     field :failed, :boolean, default: false
     field :deleted_number, :integer
-    field :currency, :string, autogenerate: {Siwapp.Settings, :value, [:currency]}
+    field :currency, :string
     field :invoicing_address, :string
     field :shipping_address, :string
     field :notes, :string
@@ -112,6 +112,7 @@ defmodule Siwapp.Invoices.Invoice do
     invoice
     |> cast(attrs, @fields)
     |> cast_assoc(:items)
+    |> assign_currency()
     |> assign_issue_date()
     |> assign_due_date()
     |> validate_draft_enablement()

--- a/lib/siwapp/recurring_invoices/recurring_invoice.ex
+++ b/lib/siwapp/recurring_invoices/recurring_invoice.ex
@@ -91,7 +91,7 @@ defmodule Siwapp.RecurringInvoices.RecurringInvoice do
     field :period_type, :string
     field :starting_date, :date
     field :finishing_date, :date
-    field :currency, :string, autogenerate: {Siwapp.Settings, :value, [:currency]}
+    field :currency, :string
     field :deleted_at, :utc_datetime
     field :notes, :string
     field :terms, :string

--- a/lib/siwapp/recurring_invoices/recurring_invoice.ex
+++ b/lib/siwapp/recurring_invoices/recurring_invoice.ex
@@ -110,6 +110,7 @@ defmodule Siwapp.RecurringInvoices.RecurringInvoice do
     recurring_invoice
     |> cast(attrs, @fields)
     |> maybe_find_customer_or_new()
+    |> assign_currency()
     |> transform_items()
     |> validate_items()
     |> apply_changes_items()

--- a/lib/siwapp/recurring_invoices/recurring_invoice.ex
+++ b/lib/siwapp/recurring_invoices/recurring_invoice.ex
@@ -91,7 +91,7 @@ defmodule Siwapp.RecurringInvoices.RecurringInvoice do
     field :period_type, :string
     field :starting_date, :date
     field :finishing_date, :date
-    field :currency, :string
+    field :currency, :string, autogenerate: {Siwapp.Settings, :value, [:currency]}
     field :deleted_at, :utc_datetime
     field :notes, :string
     field :terms, :string

--- a/lib/siwapp/settings/setting_bundle.ex
+++ b/lib/siwapp/settings/setting_bundle.ex
@@ -28,7 +28,7 @@ defmodule Siwapp.Settings.SettingBundle do
     |> cast(attrs, @labels)
     |> validate_email()
     # Example list of currency, will be updated to whole
-    |> validate_inclusion(:currency, ["USD", "EUR"])
+    |> validate_length(:currency, max: 3)
   end
 
   @spec fields_map :: map

--- a/lib/siwapp_web/controllers/settings_controller.ex
+++ b/lib/siwapp_web/controllers/settings_controller.ex
@@ -1,6 +1,7 @@
 defmodule SiwappWeb.SettingsController do
   use SiwappWeb, :controller
 
+  alias Siwapp.Invoices
   alias Siwapp.Settings
 
   def edit(conn, _params) do
@@ -9,6 +10,7 @@ defmodule SiwappWeb.SettingsController do
 
     conn
     |> assign(:changeset, changeset)
+    |> assign(:currency_options, Invoices.list_currencies())
     |> render("edit.html")
   end
 
@@ -17,6 +19,7 @@ defmodule SiwappWeb.SettingsController do
       {:ok, changeset} ->
         conn
         |> assign(:changeset, changeset)
+        |> assign(:currency_options, Invoices.list_currencies())
         |> put_flash(:info, "Settings saved succesfully")
         |> render("edit.html")
 

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -108,11 +108,4 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
-  defp currency_options() do
-    options = ["EUR", "USD", "GBP"]
-    default = Siwapp.Settings.value(:currency)
-
-    [default | List.delete(options, default)]
-  end
-
 end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -14,7 +14,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
      socket
      |> assign(:multiselect_options, Commons.list_taxes_for_multiselect())
      |> assign(:series, Commons.list_series())
-     |> assign(:currency_options, SiwappWeb.PageView.list_currencies())
+     |> assign(:currency_options, Invoices.list_currencies())
      |> assign(:customer_suggestions, [])}
   end
 

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -14,6 +14,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
      socket
      |> assign(:multiselect_options, Commons.list_taxes_for_multiselect())
      |> assign(:series, Commons.list_series())
+     |> assign(:currency_options, SiwappWeb.PageView.list_currencies())
      |> assign(:customer_suggestions, [])}
   end
 

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -107,5 +107,4 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
-
 end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -107,4 +107,12 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
+
+  defp currency_options() do
+    options = ["EUR", "USD", "GBP"]
+    default = Siwapp.Settings.value(:currency)
+
+    [default | List.delete(options, default)]
+  end
+
 end

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -34,7 +34,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, SiwappWeb.PageView.list_currencies(:default_first), phx_debounce: "blur" %>
+          <%= select f, :currency, SiwappWeb.PageView.list_currencies(), phx_debounce: "blur" %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -34,7 +34,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, ["USD", "EUR", "GBP"], phx_debounce: "blur" %>
+          <%= select f, :currency, currency_options(), phx_debounce: "blur" %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -34,7 +34,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, currency_options(), phx_debounce: "blur" %>
+          <%= select f, :currency, SiwappWeb.PageView.list_currencies(:default_first), phx_debounce: "blur" %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -34,7 +34,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, SiwappWeb.PageView.list_currencies(), phx_debounce: "blur" %>
+          <%= select f, :currency, @currency_options, phx_debounce: "blur" %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.ex
@@ -13,6 +13,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
     {:ok,
      socket
      |> assign(:series, Commons.list_series())
+     |> assign(:currency_options, SiwappWeb.PageView.list_currencies())
      |> assign(:customer_suggestions, [])}
   end
 

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.ex
@@ -6,6 +6,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
   alias SiwappWeb.ItemView
 
   alias Siwapp.Commons
+  alias Siwapp.Invoices
   alias Siwapp.RecurringInvoices
   alias Siwapp.RecurringInvoices.RecurringInvoice
 
@@ -13,7 +14,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
     {:ok,
      socket
      |> assign(:series, Commons.list_series())
-     |> assign(:currency_options, SiwappWeb.PageView.list_currencies())
+     |> assign(:currency_options, Invoices.list_currencies())
      |> assign(:customer_suggestions, [])}
   end
 

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
@@ -81,7 +81,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, ["USD", "EUR", "GBP"] %>
+          <%= select f, :currency, SiwappWeb.PageView.list_currencies(:default_first) %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
@@ -81,7 +81,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, SiwappWeb.PageView.list_currencies(:default_first) %>
+          <%= select f, :currency, SiwappWeb.PageView.list_currencies() %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
@@ -81,7 +81,7 @@
       <div class="field">
         <%= label f, :currency, class: "label" %>
         <p class="control select is-fullwidth">
-          <%= select f, :currency, SiwappWeb.PageView.list_currencies() %>
+          <%= select f, :currency, @currency_options %>
         </p>
       </div>
     </div>

--- a/lib/siwapp_web/templates/settings/edit.html.heex
+++ b/lib/siwapp_web/templates/settings/edit.html.heex
@@ -59,7 +59,7 @@
       <div class="field">
         <%=label f, :currency, class: "label"%>
         <p class="control select is-fullwidth is-hover">
-          <%=select(f, :currency, SiwappWeb.PageView.list_currencies())%>
+          <%=select(f, :currency, @currency_options)%>
         </p>
         <%=error_tag f, :currency %>
       </div>

--- a/lib/siwapp_web/templates/settings/edit.html.heex
+++ b/lib/siwapp_web/templates/settings/edit.html.heex
@@ -59,7 +59,7 @@
       <div class="field">
         <%=label f, :currency, class: "label"%>
         <p class="control select is-fullwidth is-hover">
-          <%=select(f, :currency, ["USD", "EUR"])%>
+          <%=select(f, :currency, SiwappWeb.PageView.list_currencies())%>
         </p>
         <%=error_tag f, :currency %>
       </div>

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -11,9 +11,7 @@ defmodule SiwappWeb.PageView do
     |> Money.to_string()
   end
 
-  def list_currencies(), do: Enum.uniq(primary_currencies() ++ all_currencies())
-
-  def list_currencies(:default_first) do
+  def list_currencies() do
     default_currency = Siwapp.Settings.value(:currency)
     Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
   end

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -10,4 +10,20 @@ defmodule SiwappWeb.PageView do
     |> Money.new(currency)
     |> Money.to_string()
   end
+
+  def list_currencies(), do: Enum.uniq(primary_currencies() ++ all_currencies())
+
+  def list_currencies(:default_first) do
+    default_currency = Siwapp.Settings.value(:currency)
+    Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
+  end
+
+  defp all_currencies() do
+    Money.Currency.all()
+    |> Map.keys()
+    |> Enum.map(&Atom.to_string/1)
+    |> Enum.sort()
+  end
+
+  defp primary_currencies(), do: ["USD", "EUR", "GBP"]
 end

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -2,7 +2,7 @@ defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
   @spec set_currency(float | integer, atom | binary) :: binary
-  def set_currency(value, nil), do: set_currency(value, :USD)
+  def set_currency(value, nil), do: set_currency(value, Siwapp.Settings.value(:currency))
 
   def set_currency(value, currency) do
     value

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -2,8 +2,6 @@ defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
   @spec set_currency(float | integer, atom | binary) :: binary
-  def set_currency(value, nil), do: set_currency(value, Siwapp.Settings.value(:currency))
-
   def set_currency(value, currency) do
     value
     |> round()

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -8,18 +8,4 @@ defmodule SiwappWeb.PageView do
     |> Money.new(currency)
     |> Money.to_string()
   end
-
-  def list_currencies do
-    default_currency = Siwapp.Settings.value(:currency)
-    Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
-  end
-
-  defp all_currencies do
-    Money.Currency.all()
-    |> Map.keys()
-    |> Enum.map(&Atom.to_string/1)
-    |> Enum.sort()
-  end
-
-  defp primary_currencies, do: ["USD", "EUR", "GBP"]
 end

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -11,17 +11,17 @@ defmodule SiwappWeb.PageView do
     |> Money.to_string()
   end
 
-  def list_currencies() do
+  def list_currencies do
     default_currency = Siwapp.Settings.value(:currency)
     Enum.uniq([default_currency] ++ primary_currencies() ++ all_currencies())
   end
 
-  defp all_currencies() do
+  defp all_currencies do
     Money.Currency.all()
     |> Map.keys()
     |> Enum.map(&Atom.to_string/1)
     |> Enum.sort()
   end
 
-  defp primary_currencies(), do: ["USD", "EUR", "GBP"]
+  defp primary_currencies, do: ["USD", "EUR", "GBP"]
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -97,7 +97,7 @@ Enum.each(
 )
 
 # SEEDING INVOICES
-currencies = ["USD", "EUR", "GBP", nil]
+currencies = ["USD", "USD", "USD", "EUR", "GBP"]
 booleans = [true, false]
 
 invoices =


### PR DESCRIPTION
solves #304
solves #307 

- Campo :currency en Invoice y RecurringInvoice con valor por defecto (el configurado en Settings) asignándolo en el changeset. No hay problema con queries innecesarias en los formularios debido al select que te autoselecciona una desde el principio.
- En la selección de currencies en el formulario de Invoices, el de RecurringInvoices y Settings, ya aparecen todas las posibles currencies disponibles de la librería Money.