### PR TITLE
fix flash

### DIFF
--- a/assets/css/phoenix.scss
+++ b/assets/css/phoenix.scss
@@ -1,31 +1,34 @@
 /* Alerts and form errors used by phx.new */
+
 .alert {
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;
   border-radius: 4px;
 }
+
 .alert-info {
   color: #31708f;
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
+
 .alert-warning {
   color: #8a6d3b;
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
+
 .alert-danger {
   color: #a94442;
   background-color: #f2dede;
   border-color: #ebccd1;
 }
+
 .alert p {
   margin-bottom: 0;
 }
-.alert:empty {
-  display: none;
-}
+
 .invalid-feedback {
   color: #a94442;
   display: block;
@@ -33,6 +36,7 @@
 }
 
 /* LiveView specific classes for your customization */
+
 .phx-no-feedback.invalid-feedback,
 .phx-no-feedback .invalid-feedback {
   display: none;
@@ -43,10 +47,11 @@
   transition: opacity 1s ease-out;
 }
 
-.phx-disconnected{
+.phx-disconnected {
   cursor: wait;
 }
-.phx-disconnected *{
+
+.phx-disconnected * {
   pointer-events: none;
 }
 
@@ -59,8 +64,8 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: rgb(0,0,0);
-  background-color: rgba(0,0,0,0.4);
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .phx-modal-content {

--- a/assets/css/phoenix.scss
+++ b/assets/css/phoenix.scss
@@ -1,34 +1,28 @@
 /* Alerts and form errors used by phx.new */
-
 .alert {
   padding: 15px;
   margin-bottom: 20px;
   border: 1px solid transparent;
   border-radius: 4px;
 }
-
 .alert-info {
   color: #31708f;
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
-
 .alert-warning {
   color: #8a6d3b;
   background-color: #fcf8e3;
   border-color: #faebcc;
 }
-
 .alert-danger {
   color: #a94442;
   background-color: #f2dede;
   border-color: #ebccd1;
 }
-
 .alert p {
   margin-bottom: 0;
 }
-
 .invalid-feedback {
   color: #a94442;
   display: block;
@@ -36,7 +30,6 @@
 }
 
 /* LiveView specific classes for your customization */
-
 .phx-no-feedback.invalid-feedback,
 .phx-no-feedback .invalid-feedback {
   display: none;
@@ -51,7 +44,7 @@
   cursor: wait;
 }
 
-.phx-disconnected * {
+.phx-disconnected *{
   pointer-events: none;
 }
 
@@ -64,8 +57,8 @@
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: rgb(0, 0, 0);
-  background-color: rgba(0, 0, 0, 0.4);
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
 }
 
 .phx-modal-content {

--- a/assets/css/phoenix.scss
+++ b/assets/css/phoenix.scss
@@ -40,10 +40,9 @@
   transition: opacity 1s ease-out;
 }
 
-.phx-disconnected {
+.phx-disconnected{
   cursor: wait;
 }
-
 .phx-disconnected *{
   pointer-events: none;
 }

--- a/lib/siwapp_web/templates/layout/app.html.heex
+++ b/lib/siwapp_web/templates/layout/app.html.heex
@@ -1,16 +1,16 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @conn) %>
 <main class="container section has-navbar-fixed-bottom">
-  <%= if info = get_flash(@conn, :info) do %>
+  <%= if msg = get_flash(@conn, :info) do %>
     <p class="alert alert-info" role="alert">
-      <%= info %>
+      <%= msg %>
     </p>
   <% end %>
 
-  <%= if error = get_flash(@conn, :error) do %>
+  <%= if msg = get_flash(@conn, :error) do %>
     <p class="alert alert-danger" role="alert">
-      <%= error %>
+      <%= msg %>
     </p>
   <% end %>
-  
+
   <%= @inner_content %>
 </main>

--- a/lib/siwapp_web/templates/layout/app.html.heex
+++ b/lib/siwapp_web/templates/layout/app.html.heex
@@ -1,14 +1,14 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @conn) %>
 <main class="container section has-navbar-fixed-bottom">
-  <%= if msg = get_flash(@conn, :info) do %>
+  <%= if info_msg = get_flash(@conn, :info) do %>
     <p class="alert alert-info" role="alert">
-      <%= msg %>
+      <%= info_msg %>
     </p>
   <% end %>
 
-  <%= if msg = get_flash(@conn, :error) do %>
+  <%= if error_msg = get_flash(@conn, :error) do %>
     <p class="alert alert-danger" role="alert">
-      <%= msg %>
+      <%= error_msg %>
     </p>
   <% end %>
 

--- a/lib/siwapp_web/templates/layout/app.html.heex
+++ b/lib/siwapp_web/templates/layout/app.html.heex
@@ -1,10 +1,16 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @conn) %>
 <main class="container section has-navbar-fixed-bottom">
-  <p class="alert alert-info" role="alert">
-    <%= get_flash(@conn, :info) %>
-  </p>
-  <p class="alert alert-danger" role="alert">
-    <%= get_flash(@conn, :error) %>
-  </p>
+  <%= if info = get_flash(@conn, :info) do %>
+    <p class="alert alert-info" role="alert">
+      <%= info %>
+    </p>
+  <% end %>
+
+  <%= if error = get_flash(@conn, :error) do %>
+    <p class="alert alert-danger" role="alert">
+      <%= error %>
+    </p>
+  <% end %>
+  
   <%= @inner_content %>
 </main>

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,14 +1,14 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @socket) %>
 <main class="container section has-navbar-fixed-bottom">
-  <%= if msg = live_flash(@flash, :info) do %>
+  <%= if info_msg = live_flash(@flash, :info) do %>
     <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-      <%= msg %>
+      <%= info_msg %>
     </p>
   <% end %>
 
-  <%= if msg = live_flash(@flash, :error) do %>
+  <%= if error_msg = live_flash(@flash, :error) do %>
     <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-      <%= msg %>
+      <%= error_msg %>
     </p>
   <% end %>
 

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,12 +1,16 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @socket) %>
 <main class="container section has-navbar-fixed-bottom">
-  <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-    <%= live_flash(@flash, :info) %>
-  </p>
+  <%= if Map.has_key?(@flash, "info") do %>
+    <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
+      <%= live_flash(@flash, :info) %>
+    </p>
+  <% end %>
 
-  <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-    <%= live_flash(@flash, :error) %>
-  </p>
+  <%= if Map.has_key?(@flash, "error") do %>
+    <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
+      <%= live_flash(@flash, :error) %>
+    </p>
+  <% end %>
 
   <%= @inner_content %>
 </main>

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,16 +1,16 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @socket) %>
 <main class="container section has-navbar-fixed-bottom">
-  <%= if Map.has_key?(@flash, "info") do %>
+  <%= if info = live_flash(@flash, :info) do %>
     <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-      <%= live_flash(@flash, :info) %>
+      <%= info %>
     </p>
   <% end %>
 
-  <%= if Map.has_key?(@flash, "error") do %>
+  <%= if error = live_flash(@flash, :error) do %>
     <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-      <%= live_flash(@flash, :error) %>
+      <%= error %>
     </p>
   <% end %>
-
+  
   <%= @inner_content %>
 </main>

--- a/lib/siwapp_web/templates/layout/live.html.heex
+++ b/lib/siwapp_web/templates/layout/live.html.heex
@@ -1,16 +1,16 @@
 <%= render(SiwappWeb.LayoutView, "nav.html", socket_or_conn: @socket) %>
 <main class="container section has-navbar-fixed-bottom">
-  <%= if info = live_flash(@flash, :info) do %>
+  <%= if msg = live_flash(@flash, :info) do %>
     <p class="alert alert-info" role="alert" phx-click="lv:clear-flash" phx-value-key="info">
-      <%= info %>
+      <%= msg %>
     </p>
   <% end %>
 
-  <%= if error = live_flash(@flash, :error) do %>
+  <%= if msg = live_flash(@flash, :error) do %>
     <p class="alert alert-danger" role="alert" phx-click="lv:clear-flash" phx-value-key="error">
-      <%= error %>
+      <%= msg %>
     </p>
   <% end %>
-  
+
   <%= @inner_content %>
 </main>


### PR DESCRIPTION
Antes funcionaba con el selector :empty sobre la etiqueta. Si estaba empty ponía 'display: none', y sino no. El problema viene que con el nuevo formateo detecta el carácter 'nueva línea' como un elemento y por tanto no esta vacío, y entonces no le aplica el 'display none'.

No he encontrado forma de hacer que no detecte el carácter 'nueva línea' como contenido. La solución propuesta es verificando con un if si hay contenido en el assign @flash.

Otra posible solución sería sino también hacer que el formateo obvie estos dos ficheros, pero me parece peor.