### PR TITLE
usando siempre la librería money

### DIFF
--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -92,7 +92,7 @@ defmodule Siwapp.Invoices do
 
     items_with_calculations =
       invoice.items
-      |> Enum.map(&change_item/1)
+      |> Enum.map(&change_item(&1, invoice.currency))
       |> Enum.map(&Ecto.Changeset.apply_changes/1)
 
     Map.put(invoice, :items, items_with_calculations)
@@ -159,11 +159,12 @@ defmodule Siwapp.Invoices do
   Creates an item associated to an invoice
   """
 
-  @spec create_item(Invoice.t(), map()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
-  def create_item(%Invoice{} = invoice, attrs \\ %{}) do
+  @spec create_item(Invoice.t(), atom() | binary(), map()) ::
+          {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
+  def create_item(%Invoice{} = invoice, currency, attrs \\ %{}) do
     invoice
     |> Ecto.build_assoc(:items)
-    |> Item.changeset(attrs)
+    |> Item.changeset(attrs, currency)
     |> Repo.insert()
   end
 
@@ -171,11 +172,12 @@ defmodule Siwapp.Invoices do
   Updates an item
   """
 
-  @spec update_item(Item.t(), map()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
-  def update_item(%Item{} = item, attrs) do
+  @spec update_item(Item.t(), atom() | binary(), map()) ::
+          {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
+  def update_item(%Item{} = item, currency, attrs) do
     item
     |> Repo.preload(:taxes)
-    |> Item.changeset(attrs)
+    |> Item.changeset(attrs, currency)
     |> Repo.update()
   end
 
@@ -186,7 +188,7 @@ defmodule Siwapp.Invoices do
   @spec delete_item(Item.t()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
   def delete_item(%Item{} = item), do: Repo.delete(item)
 
-  def change_item(%Item{} = item, attrs \\ %{}) do
-    Item.changeset(item, attrs)
+  def change_item(%Item{} = item, currency, attrs \\ %{}) do
+    Item.changeset(item, attrs, currency)
   end
 end

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -110,8 +110,8 @@ defmodule Siwapp.Invoices.Invoice do
   def changeset(invoice, attrs \\ %{}) do
     invoice
     |> cast(attrs, @fields)
-    |> cast_assoc(:items)
     |> assign_currency()
+    |> cast_items()
     |> assign_issue_date()
     |> assign_due_date()
     |> only_new_invoice_can_be_draft()
@@ -128,6 +128,12 @@ defmodule Siwapp.Invoices.Invoice do
     |> validate_length(:contact_person, max: 100)
     |> validate_length(:currency, max: 3)
     |> calculate()
+  end
+
+  @spec cast_items(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def cast_items(changeset) do
+    currency = get_field(changeset, :currency)
+    cast_assoc(changeset, :items, with: {Item, :changeset, [currency]})
   end
 
   @doc """

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -151,7 +151,7 @@ defmodule Siwapp.Invoices.Item do
 
       true ->
         case Money.parse(virtual_unitary_cost, currency) do
-          {:ok, money} -> put_change(changeset, :unitary_cost, money.amount)
+          {:ok, %Money{amount: amount}} -> put_change(changeset, :unitary_cost, amount)
           :error -> add_error(changeset, :virtual_unitary_cost, "Invalid format")
         end
     end

--- a/lib/siwapp/recurring_invoices/recurring_invoice.ex
+++ b/lib/siwapp/recurring_invoices/recurring_invoice.ex
@@ -149,9 +149,9 @@ defmodule Siwapp.RecurringInvoices.RecurringInvoice do
   # Converts field items from list of maps to list of Item changesets.
   # This is used to handle items validation and calculations
   defp transform_items(changeset) do
-    items_transformed =
-      get_field(changeset, :items)
-      |> Enum.map(&Item.changeset(%Item{}, &1))
+    items = get_field(changeset, :items)
+    currency = get_field(changeset, :currency)
+    items_transformed = Enum.map(items, &Item.changeset(%Item{}, &1, currency))
 
     put_change(changeset, :items, items_transformed)
   end
@@ -183,11 +183,11 @@ defmodule Siwapp.RecurringInvoices.RecurringInvoice do
   # Used to recycle add_item, remove_item functions in views and
   # build item forms' for user to fill
   defp unapply_changes_items(changeset) do
-    items =
-      get_field(changeset, :items)
-      |> Enum.map(&Item.changeset(&1, %{}))
+    items = get_field(changeset, :items)
+    currency = get_field(changeset, :currency)
+    items_changeset = Enum.map(items, &Item.changeset(&1, %{}, currency))
 
-    put_change(changeset, :items, items)
+    put_change(changeset, :items, items_changeset)
   end
 
   defp make_item(%Item{description: d, quantity: q, unitary_cost: u, discount: di, taxes: t}) do

--- a/lib/siwapp_web/templates/item/item_form.html.heex
+++ b/lib/siwapp_web/templates/item/item_form.html.heex
@@ -47,7 +47,7 @@
       </label>
       <p class="control">
         <a class="button is-static is-fullwidth">
-          <%= item_net_amount(fi) %>
+          <%= item_net_amount(@changeset, fi) %>
         </a>
       </p>
     </div>

--- a/lib/siwapp_web/views/item_view.ex
+++ b/lib/siwapp_web/views/item_view.ex
@@ -13,16 +13,17 @@ defmodule SiwappWeb.ItemView do
     |> Enum.map(&{&1.name, &1.id})
   end
 
-  @spec item_net_amount(FormData.t()) :: binary
-  def item_net_amount(fi) do
-    (get_field(fi.source, :net_amount) / 100)
-    |> :erlang.float_to_binary(decimals: 2)
+  @spec item_net_amount(Ecto.Changeset.t(), FormData.t()) :: binary
+  def item_net_amount(changeset, fi) do
+    value = get_field(fi.source, :net_amount)
+    currency = get_field(changeset, :currency)
+    PageView.set_currency(value, currency, symbol: false, separator: "")
   end
 
   def add_item(changeset) do
     items =
       get_field(changeset, :items) ++
-        [Item.changeset(%Item{}, %{})]
+        [Item.changeset(%Item{}, %{}, get_field(changeset, :currency))]
 
     put_change(changeset, :items, items)
   end

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -1,18 +1,14 @@
 defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
-  @spec set_currency(float | integer, atom | binary) :: binary
-  def set_currency(value, currency) do
-    value
-    |> round()
-    |> Money.new(currency)
-    |> Money.to_string()
-  end
+  @spec set_currency(number, atom | binary, keyword) :: binary
+  def set_currency(value, currency, options \\ []) do
+    default = [symbol: true, separator: ","]
+    options = Keyword.merge(default, options)
 
-  def set_currency(value, currency, symbol: symbol) do
     value
     |> round()
     |> Money.new(currency)
-    |> Money.to_string(symbol: symbol)
+    |> Money.to_string(symbol: options[:symbol], separator: options[:separator])
   end
 end


### PR DESCRIPTION
Este PR era fundamentalmente para en el changeset de items a la hora de pasar de virtual_unitary_cost a unitary_cost y viceversa se hiciera siempre a través de la librería Money.

La única complicación es que se necesita el currency para jugar con objetos Money. La solución es hacer un cast_assoc desde el changeset de invoices al de items pasándole como parámetro el currency. Por ello ahora el changeset de items tiene tres parámetros de entrada.

También he mejorado un poquito la función set currency del módulo PageView, y he modificado todas las llamadas al changeset de items con los tres argumentos de entrada