### PR TITLE
Rodri/unificar invoices list

### DIFF
--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -29,16 +29,6 @@ defmodule Siwapp.Invoices do
     |> Repo.all()
   end
 
-  @spec list_past_due(integer(), integer()) :: [Invoice.t()]
-  def list_past_due(limit \\ 20, offset \\ 0) do
-    Invoice
-    |> InvoiceQuery.list_past_due()
-    |> limit(^limit)
-    |> offset(^offset)
-    |> Query.list_preload(:series)
-    |> Repo.all()
-  end
-
   @spec count :: integer | nil
   def count do
     Repo.aggregate(Invoice, :count)

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -29,10 +29,12 @@ defmodule Siwapp.Invoices do
     |> Repo.all()
   end
 
-  @spec scroll_listing(integer, integer) :: [Invoice.t()]
-  def scroll_listing(page, per_page \\ 20) do
+  @spec list_past_due(integer(), integer()) :: [Invoice.t()]
+  def list_past_due(limit \\ 20, offset \\ 0) do
     Invoice
-    |> Query.paginate(page, per_page)
+    |> InvoiceQuery.list_past_due()
+    |> limit(^limit)
+    |> offset(^offset)
     |> Query.list_preload(:series)
     |> Repo.all()
   end
@@ -122,15 +124,6 @@ defmodule Siwapp.Invoices do
     invoice
     |> Invoice.changeset(attrs)
     |> Invoice.assign_number()
-  end
-
-  @spec list_past_due(integer, integer) :: [Invoice.t()]
-  def list_past_due(page, per_page \\ 20) do
-    Invoice
-    |> InvoiceQuery.list_past_due()
-    |> Query.paginate(page, per_page)
-    |> Query.list_preload(:series)
-    |> Repo.all()
   end
 
   @spec status(Invoice.t()) :: :draft | :failed | :paid | :pending | :past_due

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -136,7 +136,7 @@ defmodule Siwapp.Invoices do
 
   @spec due_date_status(DateTime.t()) :: :pendig | :past_due
   defp due_date_status(due_date) do
-    if Date.diff(due_date, Date.utc_today()) > 0 do
+    if Date.diff(due_date, Date.utc_today()) >= 0 do
       :pending
     else
       :past_due

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -48,6 +48,9 @@ defmodule Siwapp.Invoices.InvoiceQuery do
     |> limit(1)
   end
 
+  @doc """
+  Gets a query on the invoices that match with the params
+  """
   @spec list_by_query(
           Ecto.Query.t(),
           :customer_id
@@ -58,10 +61,6 @@ defmodule Siwapp.Invoices.InvoiceQuery do
           | :with_terms,
           any
         ) :: Ecto.Query.t()
-  @doc """
-  Gets a query on the invoices that match with the params
-  """
-  @spec list_by_query(Ecto.Query.t(), atom, any) :: Ecto.Query.t()
   def list_by_query(query, key, value) do
     case {key, value} do
       {:with_terms, value} ->

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -4,6 +4,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
   """
   import Ecto.Query
 
+  @spec past_due(Ecto.Query.t()) :: Ecto.Query.t()
   def past_due(query) do
     date_today = Date.utc_today()
 
@@ -57,6 +58,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
   @doc """
   Gets a query on the invoices that match with the params
   """
+  @spec list_by_query(Ecto.Query.t(), atom, any) :: Ecto.Query.t()
   def list_by_query(query, key, value) do
     case {key, value} do
       {:with_terms, value} ->

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -4,8 +4,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
   """
   import Ecto.Query
 
-  @spec list_past_due(Ecto.Queryable.t()) :: Ecto.Query.t()
-  def list_past_due(query) do
+  def past_due(query) do
     date_today = Date.utc_today()
 
     query
@@ -76,11 +75,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
         where(query, series_id: ^value)
 
       {:with_status, :past_due} ->
-        date_today = Date.utc_today()
-
-        query
-        |> where([i], not is_nil(i.due_date))
-        |> where([i], i.due_date < ^date_today)
+        past_due(query)
 
       {:with_status, value} ->
         where(query, ^[{value, true}])

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -13,7 +13,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
     |> where(paid: false)
     |> where(failed: false)
     |> where([i], not is_nil(i.due_date))
-    |> where([i], i.due_date < ^date_today)
+    |> where([i], i.due_date <= ^date_today)
   end
 
   @spec with_terms(Ecto.Queryable.t(), any) :: Ecto.Query.t()

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -4,6 +4,9 @@ defmodule Siwapp.Invoices.InvoiceQuery do
   """
   import Ecto.Query
 
+  @doc """
+  Gets a query on the invoices with status :past_due
+  """
   @spec past_due(Ecto.Query.t()) :: Ecto.Query.t()
   def past_due(query) do
     date_today = Date.utc_today()

--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -16,7 +16,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
     |> where(paid: false)
     |> where(failed: false)
     |> where([i], not is_nil(i.due_date))
-    |> where([i], i.due_date <= ^date_today)
+    |> where([i], i.due_date < ^date_today)
   end
 
   @spec with_terms(Ecto.Queryable.t(), any) :: Ecto.Query.t()

--- a/lib/siwapp/recurring_invoices.ex
+++ b/lib/siwapp/recurring_invoices.ex
@@ -12,17 +12,15 @@ defmodule Siwapp.RecurringInvoices do
   alias Siwapp.RecurringInvoices.RecurringInvoice
   alias Siwapp.Repo
 
-  @spec list :: [RecurringInvoice.t()]
-  def list do
-    # query = Query.invoices()
-    Repo.all(RecurringInvoice)
-  end
+  @spec list(keyword()) :: [RecurringInvoice.t()]
+  def list(options \\ []) do
+    default = [limit: 100, offset: 0, preload: []]
+    options = Keyword.merge(default, options)
 
-  @spec scroll_listing(integer, integer) :: [RecurringInvoice.t()]
-  def scroll_listing(page, per_page \\ 20) do
     RecurringInvoice
-    |> Query.paginate(page, per_page)
-    |> Query.list_preload(:series)
+    |> limit(^options[:limit])
+    |> offset(^options[:offset])
+    |> Query.list_preload(options[:preload])
     |> Repo.all()
   end
 

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -13,7 +13,8 @@ defmodule SiwappWeb.InvoicesLive.Index do
      |> assign(:page, 0)
      |> assign(
        :invoices,
-       Invoices.list(limit: 20, offset: 0, preload: [:series], filters: [with_status: :past_due]))
+       Invoices.list(limit: 20, offset: 0, preload: [:series], filters: [with_status: :past_due])
+     )
      |> assign(:checked, MapSet.new())}
   end
 

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -45,7 +45,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:invoices, Invoices.scroll_listing(0))
+     |> assign(:invoices, Invoices.list(limit: 20, offset: 0, preload: [:series]))
      |> assign(:number_of_invoices, Invoices.count())
      |> assign(:checked, MapSet.new())
      |> assign(:summary_state, set_summary(:closed))
@@ -104,7 +104,8 @@ defmodule SiwappWeb.InvoicesLive.Index do
     {
       :noreply,
       assign(socket,
-        invoices: invoices ++ Invoices.scroll_listing(page + 1),
+        invoices:
+          invoices ++ Invoices.list(limit: 20, offset: (page + 1) * 20, preload: [:series]),
         page: page + 1
       )
     }

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -11,7 +11,9 @@ defmodule SiwappWeb.InvoicesLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:invoices, Invoices.list_past_due(0))
+     |> assign(
+       :invoices,
+       Invoices.list(limit: 20, offset: 0, preload: [:series], filters: [with_status: :past_due]))
      |> assign(:checked, MapSet.new())}
   end
 
@@ -65,7 +67,14 @@ defmodule SiwappWeb.InvoicesLive.Index do
     {
       :noreply,
       assign(socket,
-        invoices: invoices ++ Invoices.list_past_due(page + 1),
+        invoices:
+          invoices ++
+            Invoices.list(
+              limit: 20,
+              offset: (page + 1) * 20,
+              preload: [:series],
+              filters: [with_status: :past_due]
+            ),
         page: page + 1
       )
     }

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -12,7 +12,10 @@ defmodule SiwappWeb.PageLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:invoices, Invoices.list_past_due(20, 0))}
+     |> assign(
+       :invoices,
+       Invoices.list(limit: 20, offset: 0, preload: [:series], filters: [with_status: :past_due])
+     )}
   end
 
   @doc """
@@ -36,7 +39,14 @@ defmodule SiwappWeb.PageLive.Index do
     {
       :noreply,
       assign(socket,
-        invoices: invoices ++ Invoices.list_past_due(20, (page + 1) * 20),
+        invoices:
+          invoices ++
+            Invoices.list(
+              limit: 20,
+              offset: (page + 1) * 20,
+              preload: [:series],
+              filters: [with_status: :past_due]
+            ),
         page: page + 1
       )
     }

--- a/lib/siwapp_web/live/page_live/index.ex
+++ b/lib/siwapp_web/live/page_live/index.ex
@@ -12,7 +12,7 @@ defmodule SiwappWeb.PageLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:invoices, Invoices.list_past_due(0))}
+     |> assign(:invoices, Invoices.list_past_due(20, 0))}
   end
 
   @doc """
@@ -36,7 +36,7 @@ defmodule SiwappWeb.PageLive.Index do
     {
       :noreply,
       assign(socket,
-        invoices: invoices ++ Invoices.list_past_due(page + 1),
+        invoices: invoices ++ Invoices.list_past_due(20, (page + 1) * 20),
         page: page + 1
       )
     }

--- a/lib/siwapp_web/live/recurring_invoices_live/index.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/index.ex
@@ -12,7 +12,10 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:recurring_invoices, RecurringInvoices.scroll_listing(0))
+     |> assign(
+       :recurring_invoices,
+       RecurringInvoices.list(limit: 20, offset: 0, preload: [:series])
+     )
      |> assign(:checked, MapSet.new())}
   end
 
@@ -26,7 +29,9 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
     {
       :noreply,
       assign(socket,
-        recurring_invoices: recurring_invoices ++ RecurringInvoices.scroll_listing(page + 1),
+        recurring_invoices:
+          recurring_invoices ++
+            RecurringInvoices.list(limit: 20, offset: (page + 1) * 20, preload: [:series]),
         page: page + 1
       )
     }


### PR DESCRIPTION
Ya que había muchas Invoices.list he unificado varias en una sola. De esta manera el scroll_listing sobra y se puede llamar a Invoices.list(limit: 20, offset: 30) por ejemplo. Y coge las 20 primeras invoices a partir de la 31. Lo mismo para recurring invoices.

Así manejamos los parámetros de entrada limit y offset más propios de sql y no usamos el paginate con el page y per_page