### PR TITLE
payments

### DIFF
--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -205,7 +205,7 @@ defmodule Siwapp.Invoices do
   @doc """
   Creates a payment associated to an invoice
   """
-  @spec create_payment(Invoice.t(), atom() | binary(), map()) ::
+  @spec create_payment(Invoice.t(), map()) ::
           {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
   def create_payment(%Invoice{} = invoice, attrs \\ %{}) do
     invoice
@@ -217,7 +217,7 @@ defmodule Siwapp.Invoices do
   @doc """
   Updates a payment
   """
-  @spec update_payment(Payment.t(), atom() | binary(), map()) ::
+  @spec update_payment(Payment.t(), map()) ::
           {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
   def update_payment(%Payment{} = payment, attrs) do
     payment
@@ -234,7 +234,7 @@ defmodule Siwapp.Invoices do
   @doc """
   Change a payment
   """
-  @spec change_payment(Payment.t(), binary | atom, map) :: Ecto.Changeset.t()
+  @spec change_payment(Payment.t(), map) :: Ecto.Changeset.t()
   def change_payment(%Payment{} = payment, attrs \\ %{}) do
     Payment.changeset(payment, attrs)
   end

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -8,6 +8,7 @@ defmodule Siwapp.Invoices do
   alias Siwapp.Invoices.Invoice
   alias Siwapp.Invoices.InvoiceQuery
   alias Siwapp.Invoices.Item
+  alias Siwapp.Invoices.Payment
   alias Siwapp.Query
   alias Siwapp.Repo
 
@@ -160,7 +161,6 @@ defmodule Siwapp.Invoices do
   @doc """
   Creates an item associated to an invoice
   """
-
   @spec create_item(Invoice.t(), atom() | binary(), map()) ::
           {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
   def create_item(%Invoice{} = invoice, currency, attrs \\ %{}) do
@@ -173,7 +173,6 @@ defmodule Siwapp.Invoices do
   @doc """
   Updates an item
   """
-
   @spec update_item(Item.t(), atom() | binary(), map()) ::
           {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
   def update_item(%Item{} = item, currency, attrs) do
@@ -186,12 +185,57 @@ defmodule Siwapp.Invoices do
   @doc """
   Deletes an item
   """
-
   @spec delete_item(Item.t()) :: {:ok, Item.t()} | {:error, Ecto.Changeset.t()}
   def delete_item(%Item{} = item), do: Repo.delete(item)
 
+  @doc """
+  Change an item
+  """
   @spec change_item(Item.t(), binary | atom, map) :: Ecto.Changeset.t()
   def change_item(%Item{} = item, currency, attrs \\ %{}) do
     Item.changeset(item, attrs, currency)
+  end
+
+  @doc """
+  Gets a payment by id
+  """
+  @spec get_payment_by_id!(pos_integer()) :: Payment.t()
+  def get_payment_by_id!(id), do: Repo.get!(Payment, id)
+
+  @doc """
+  Creates a payment associated to an invoice
+  """
+  @spec create_payment(Invoice.t(), atom() | binary(), map()) ::
+          {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
+  def create_payment(%Invoice{} = invoice, attrs \\ %{}) do
+    invoice
+    |> Ecto.build_assoc(:payments)
+    |> Payment.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a payment
+  """
+  @spec update_payment(Payment.t(), atom() | binary(), map()) ::
+          {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
+  def update_payment(%Payment{} = payment, attrs) do
+    payment
+    |> Payment.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a payment
+  """
+  @spec delete_payment(Payment.t()) :: {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
+  def delete_payment(%Payment{} = payment), do: Repo.delete(payment)
+
+  @doc """
+  Change a payment
+  """
+  @spec change_payment(Payment.t(), binary | atom, map) :: Ecto.Changeset.t()
+  def change_payment(%Payment{} = payment, attrs \\ %{}) do
+    Payment.changeset(payment, attrs)
   end
 end

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -205,23 +205,23 @@ defmodule Siwapp.Invoices do
   @doc """
   Creates a payment associated to an invoice
   """
-  @spec create_payment(Invoice.t(), map()) ::
+  @spec create_payment(Invoice.t(), atom() | binary(), map()) ::
           {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
-  def create_payment(%Invoice{} = invoice, attrs \\ %{}) do
+  def create_payment(%Invoice{} = invoice, currency, attrs \\ %{}) do
     invoice
     |> Ecto.build_assoc(:payments)
-    |> Payment.changeset(attrs)
+    |> Payment.changeset(attrs, currency)
     |> Repo.insert()
   end
 
   @doc """
   Updates a payment
   """
-  @spec update_payment(Payment.t(), map()) ::
+  @spec update_payment(Payment.t(), atom() | binary(), map()) ::
           {:ok, Payment.t()} | {:error, Ecto.Changeset.t()}
-  def update_payment(%Payment{} = payment, attrs) do
+  def update_payment(%Payment{} = payment, currency, attrs) do
     payment
-    |> Payment.changeset(attrs)
+    |> Payment.changeset(attrs, currency)
     |> Repo.update()
   end
 
@@ -234,8 +234,8 @@ defmodule Siwapp.Invoices do
   @doc """
   Change a payment
   """
-  @spec change_payment(Payment.t(), map) :: Ecto.Changeset.t()
-  def change_payment(%Payment{} = payment, attrs \\ %{}) do
-    Payment.changeset(payment, attrs)
+  @spec change_payment(Payment.t(), atom() | binary(), map) :: Ecto.Changeset.t()
+  def change_payment(%Payment{} = payment, currency, attrs \\ %{}) do
+    Payment.changeset(payment, attrs, currency)
   end
 end

--- a/lib/siwapp/invoices/amount_helper.ex
+++ b/lib/siwapp/invoices/amount_helper.ex
@@ -1,0 +1,42 @@
+defmodule Siwapp.Invoices.AmountHelper do
+  import Ecto.Changeset
+
+  alias SiwappWeb.PageView
+
+  @moduledoc """
+  Helper functions for Item and Payments schemas when handling with amounts
+  """
+
+  @spec set_amount(Ecto.Changeset.t(), atom(), atom(), atom() | binary()) :: Ecto.Changeset.t()
+  def set_amount(changeset, field, virtual_field, currency) do
+    virtual_amount = IO.inspect get_field(changeset, virtual_field)
+
+    cond do
+      is_nil(virtual_amount) ->
+        changeset
+
+      virtual_amount == "" ->
+        put_change(changeset, field, 0)
+
+      true ->
+        case Money.parse(virtual_amount, currency) do
+          {:ok, %Money{amount: amount}} -> put_change(changeset, field, amount)
+          :error -> add_error(changeset, virtual_field, "Invalid format")
+        end
+    end
+  end
+
+  @spec set_virtual_amount(Ecto.Changeset.t(), atom(), atom(), atom() | binary()) :: Ecto.Changeset.t()
+  def set_virtual_amount(changeset, field, virtual_field, currency) do
+    if is_nil(get_field(changeset, field)) do
+      changeset
+    else
+      amount = get_field(changeset, field)
+
+      virtual_amount =
+        PageView.money_format(amount, currency, symbol: false, separator: "")
+
+      put_change(changeset, virtual_field, virtual_amount)
+    end
+  end
+end

--- a/lib/siwapp/invoices/amount_helper.ex
+++ b/lib/siwapp/invoices/amount_helper.ex
@@ -1,15 +1,14 @@
 defmodule Siwapp.Invoices.AmountHelper do
+  @moduledoc """
+  Helper functions for Item and Payments schemas when handling with amounts
+  """
   import Ecto.Changeset
 
   alias SiwappWeb.PageView
 
-  @moduledoc """
-  Helper functions for Item and Payments schemas when handling with amounts
-  """
-
   @spec set_amount(Ecto.Changeset.t(), atom(), atom(), atom() | binary()) :: Ecto.Changeset.t()
   def set_amount(changeset, field, virtual_field, currency) do
-    virtual_amount = IO.inspect get_field(changeset, virtual_field)
+    virtual_amount = get_field(changeset, virtual_field)
 
     cond do
       is_nil(virtual_amount) ->
@@ -26,15 +25,15 @@ defmodule Siwapp.Invoices.AmountHelper do
     end
   end
 
-  @spec set_virtual_amount(Ecto.Changeset.t(), atom(), atom(), atom() | binary()) :: Ecto.Changeset.t()
+  @spec set_virtual_amount(Ecto.Changeset.t(), atom(), atom(), atom() | binary()) ::
+          Ecto.Changeset.t()
   def set_virtual_amount(changeset, field, virtual_field, currency) do
     if is_nil(get_field(changeset, field)) do
       changeset
     else
       amount = get_field(changeset, field)
 
-      virtual_amount =
-        PageView.money_format(amount, currency, symbol: false, separator: "")
+      virtual_amount = PageView.money_format(amount, currency, symbol: false, separator: "")
 
       put_change(changeset, virtual_field, virtual_amount)
     end

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -145,7 +145,7 @@ defmodule Siwapp.Invoices.Invoice do
   @spec cast_payments(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   def cast_payments(changeset) do
     currency = get_field(changeset, :currency)
-    cast_assoc(changeset, :payments)
+    cast_assoc(changeset, :payments, with: {Payment, :changeset, [currency]})
   end
 
   @doc """

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -11,6 +11,7 @@ defmodule Siwapp.Invoices.Invoice do
   alias Siwapp.Customers.Customer
   alias Siwapp.Invoices.InvoiceQuery
   alias Siwapp.Invoices.Item
+  alias Siwapp.Invoices.Payment
   alias Siwapp.RecurringInvoices.RecurringInvoice
   alias Siwapp.Repo
 
@@ -63,6 +64,7 @@ defmodule Siwapp.Invoices.Invoice do
           currency: <<_::24>> | nil,
           due_date: Date.t() | nil,
           items: Ecto.Association.NotLoaded.t() | [Item.t()],
+          payments: Ecto.Association.NotLoaded.t() | [Payment.t()],
           sent_by_email: boolean(),
           paid_amount: non_neg_integer(),
           draft: boolean(),
@@ -104,6 +106,7 @@ defmodule Siwapp.Invoices.Invoice do
     belongs_to :customer, Customer, on_replace: :nilify
     belongs_to :recurring_invoice, RecurringInvoice
     has_many :items, Item, on_replace: :delete
+    has_many :payments, Payment, on_replace: :delete
 
     timestamps()
   end
@@ -114,6 +117,7 @@ defmodule Siwapp.Invoices.Invoice do
     |> cast(attrs, @fields)
     |> assign_currency()
     |> cast_items()
+    |> cast_payments()
     |> assign_issue_date()
     |> assign_due_date()
     |> only_new_invoice_can_be_draft()
@@ -136,6 +140,12 @@ defmodule Siwapp.Invoices.Invoice do
   def cast_items(changeset) do
     currency = get_field(changeset, :currency)
     cast_assoc(changeset, :items, with: {Item, :changeset, [currency]})
+  end
+
+  @spec cast_payments(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def cast_payments(changeset) do
+    currency = get_field(changeset, :currency)
+    cast_assoc(changeset, :payments)
   end
 
   @doc """

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -5,6 +5,7 @@ defmodule Siwapp.Invoices.Payment do
   use Ecto.Schema
   import Ecto.Changeset
   alias Siwapp.Invoices.Invoice
+  alias SiwappWeb.PageView
 
   @fields [
     :date,
@@ -26,18 +27,65 @@ defmodule Siwapp.Invoices.Payment do
 
   schema "payments" do
     field :date, :date
-    field :amount, :integer
+    field :amount, :integer, default: 0
     field :notes, :string
     field :deleted_at, :utc_datetime
+    field :virtual_amount, :float, virtual: true, default: 0.0
     belongs_to :invoice, Invoice
 
     timestamps()
   end
 
   @spec changeset(t(), map) :: Ecto.Changeset.t()
-  def changeset(payment, attrs \\ %{}) do
+  def changeset(payment, attrs \\ %{}, currency) do
     payment
     |> cast(attrs, @fields)
+    |> assign_date()
+    |> set_amount(attrs, currency)
     |> foreign_key_constraint(:invoice_id)
+    |> set_virtual_amount(currency)
+  end
+
+  @spec assign_date(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  defp assign_date(changeset) do
+    if get_field(changeset, :date) do
+      changeset
+    else
+      put_change(changeset, :date, Date.utc_today())
+    end
+  end
+
+  @spec set_amount(Ecto.Changeset.t(), map, atom() | binary()) :: Ecto.Changeset.t()
+  def set_amount(changeset, attrs, currency) do
+    virtual_amount =
+      Map.get(attrs, :virtual_amount) || Map.get(attrs, "virtual_amount")
+
+    cond do
+      is_nil(virtual_amount) ->
+        changeset
+
+      virtual_amount == "" ->
+        put_change(changeset, :amount, 0)
+
+      true ->
+        case Money.parse(virtual_amount, currency) do
+          {:ok, %Money{amount: amount}} -> put_change(changeset, :amount, amount)
+          :error -> add_error(changeset, :virtual_amount, "Invalid format")
+        end
+    end
+  end
+
+  @spec set_virtual_amount(Ecto.Changeset.t(), atom() | binary()) :: Ecto.Changeset.t()
+  def set_virtual_amount(changeset, currency) do
+    if is_nil(get_field(changeset, :amount)) do
+      changeset
+    else
+      amount = get_field(changeset, :amount)
+
+      virtual_amount =
+        PageView.money_format(amount, currency, symbol: false, separator: "")
+
+      put_change(changeset, :virtual_amount, virtual_amount)
+    end
   end
 end

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -1,0 +1,43 @@
+defmodule Siwapp.Invoices.Payment do
+  @moduledoc """
+  Payment
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Siwapp.Invoices.Invoice
+
+  @fields [
+    :date,
+    :amount,
+    :notes,
+    :deleted_at,
+    :invoice_id
+  ]
+
+  @type t :: %__MODULE__{
+          id: pos_integer() | nil,
+          amount: pos_integer(),
+          notes: binary() | nil,
+          updated_at: DateTime.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          deleted_at: DateTime.t() | nil,
+          invoice_id: pos_integer() | nil
+        }
+
+  schema "items" do
+    field :date, :date
+    field :amount, :integer
+    field :notes, :string
+    field :deleted_at, :utc_datetime
+    belongs_to :invoice, Invoice
+
+    timestamps()
+  end
+
+  @spec changeset(t(), map) :: Ecto.Changeset.t()
+  def changeset(payment, attrs \\ %{}) do
+    payment
+    |> cast(attrs, @fields)
+    |> foreign_key_constraint(:invoice_id)
+  end
+end

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -24,7 +24,7 @@ defmodule Siwapp.Invoices.Payment do
           invoice_id: pos_integer() | nil
         }
 
-  schema "items" do
+  schema "payments" do
     field :date, :date
     field :amount, :integer
     field :notes, :string

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -18,12 +18,13 @@ defmodule Siwapp.Invoices.Payment do
 
   @type t :: %__MODULE__{
           id: pos_integer() | nil,
-          amount: pos_integer(),
+          amount: non_neg_integer(),
           notes: binary() | nil,
           updated_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
           deleted_at: DateTime.t() | nil,
-          invoice_id: pos_integer() | nil
+          invoice_id: pos_integer() | nil,
+          virtual_amount: float() | nil
         }
 
   schema "payments" do
@@ -37,7 +38,7 @@ defmodule Siwapp.Invoices.Payment do
     timestamps()
   end
 
-  @spec changeset(t(), map) :: Ecto.Changeset.t()
+  @spec changeset(t(), map, atom() | binary()) :: Ecto.Changeset.t()
   def changeset(payment, attrs \\ %{}, currency) do
     payment
     |> cast(attrs, @fields)

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -11,7 +11,6 @@ defmodule Siwapp.Invoices.Payment do
     :date,
     :amount,
     :notes,
-    :deleted_at,
     :invoice_id,
     :virtual_amount
   ]
@@ -22,7 +21,6 @@ defmodule Siwapp.Invoices.Payment do
           notes: binary() | nil,
           updated_at: DateTime.t() | nil,
           inserted_at: DateTime.t() | nil,
-          deleted_at: DateTime.t() | nil,
           invoice_id: pos_integer() | nil,
           virtual_amount: float() | nil
         }
@@ -31,7 +29,6 @@ defmodule Siwapp.Invoices.Payment do
     field :date, :date
     field :amount, :integer, default: 0
     field :notes, :string
-    field :deleted_at, :utc_datetime
     field :virtual_amount, :float, virtual: true
     belongs_to :invoice, Invoice
 

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -65,12 +65,9 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     existing_payments = Map.get(socket.assigns.changeset.changes, :payments, [])
     currency = Ecto.Changeset.get_field(socket.assigns.changeset, :currency)
 
-    payments =
-      existing_payments ++ [Invoices.change_payment(%Payment{}, currency)]
+    payments = existing_payments ++ [Invoices.change_payment(%Payment{}, currency)]
 
-    changeset =
-      socket.assigns.changeset
-      |> Ecto.Changeset.put_assoc(:payments, payments)
+    changeset = Ecto.Changeset.put_assoc(socket.assigns.changeset, :payments, payments)
 
     {:noreply, assign(socket, changeset: changeset)}
   end
@@ -81,9 +78,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
       |> Ecto.Changeset.get_field(:payments)
       |> List.delete_at(String.to_integer(payment_index))
 
-    changeset =
-      socket.assigns.changeset
-      |> Ecto.Changeset.put_assoc(:payments, payments)
+    changeset = Ecto.Changeset.put_assoc(socket.assigns.changeset, :payments, payments)
 
     {:noreply, assign(socket, changeset: changeset)}
   end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -63,9 +63,10 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
   def handle_event("add_payment", _, socket) do
     existing_payments = Map.get(socket.assigns.changeset.changes, :payments, [])
+    currency = Ecto.Changeset.get_field(socket.assigns.changeset, :currency)
 
     payments =
-      existing_payments ++ [Invoices.change_payment(%Payment{})]
+      existing_payments ++ [Invoices.change_payment(%Payment{}, currency)]
 
     changeset =
       socket.assigns.changeset

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -64,57 +64,71 @@
       f={f}
       inputs_for={inputs_for(f, :items)}
     />
-
   </fieldset>
 
+  <%= if @live_action == :edit do %>
   <fieldset class="fieldset">
     <h2>Payments</h2>
 
-    <div class="field is-horizontal field-body">
-      <div class="field">
+    <%= for fp <- inputs_for(f, :payments) do %>
+    <div class="columns is-multiline-mobile is-1 is-variable">
+      <div class="column is-3-desktop is-full-mobile">  
         <label class="label">
           Date
         </label>
         <p class="control">
-          <input class="input" type="date">
+          <%= date_input(fp, :date, phx_debounce: "blur", class: "input") %>
         </p>
+        <%= error_tag(fp, :date) %>
       </div>
-      <div class="field">
+      <div class="column is-6-desktop is-full-mobile">  
         <label class="label">
           Notes
         </label>
         <p class="control">
-          <input class="input" type="text">
+          <%= textarea(fp, :notes, phx_debounce: "blur", class: "textarea", rows: "1") %>
         </p>
+        <%= error_tag(fp, :notes) %>
+
       </div>
-      <div class="field">
+      <div class="column is-1-desktop is-full-mobile">  
         <label class="label">
           Amount
         </label>
         <p class="control">
-          <input class="input" type="text">
+          <%= text_input(fp, :amount, class: "input") %>
         </p>
+        <%= error_tag(fp, :amount) %>
       </div>
-      <div class="field">
+      <div class="column is-narrow-desktop is-full-mobile">  
         <label class="label is-invisible is-hidden-mobile">
           invisible
         </label>
         <p class="control">
-          <button class="column is-narrow-desktop button is-danger is-light is-fullwidth">
-            Remove Payment
-          </button>
+        <% IO.inspect fp.index %>
+          <%= link("Remove Line",
+            to: "#",
+            phx_click: "remove_payment",
+            phx_value_payment_id: fp.index,
+            class: "button is-danger is-light is-fullwidth"
+          ) %>
         </p>
       </div>
     </div>
+    <% end %>
 
-    <button class="column is-narrow-desktop button is-dark is-fullwidth">
-      Add Payment
-    </button>
+    <%= link("Add Payment",
+      to: "#",
+      phx_click: "add_payment",
+      class: "button is-dark is-fullwidth column is-2"
+    ) %>
+    <br>
     <label class="checkbox">
       <input type="checkbox">
       Payment collection failed
     </label>
   </fieldset>
+  <% end %>
 
   <.live_component
     module={SiwappWeb.MetaAttributesComponent}

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -67,66 +67,66 @@
   </fieldset>
 
   <%= if @live_action == :edit do %>
-  <fieldset class="fieldset">
-    <h2>Payments</h2>
+    <fieldset class="fieldset">
+      <h2>Payments</h2>
 
-    <%= for fp <- inputs_for(f, :payments) do %>
-    <div class="columns is-multiline-mobile is-1 is-variable">
-      <div class="column is-3-desktop is-full-mobile">  
-        <label class="label">
-          Date
-        </label>
-        <p class="control">
-          <%= date_input(fp, :date, phx_debounce: "blur", class: "input") %>
-        </p>
-        <%= error_tag(fp, :date) %>
-      </div>
-      <div class="column is-6-desktop is-full-mobile">  
-        <label class="label">
-          Notes
-        </label>
-        <p class="control">
-          <%= textarea(fp, :notes, phx_debounce: "blur", class: "textarea", rows: "1") %>
-        </p>
-        <%= error_tag(fp, :notes) %>
+      <%= for fp <- inputs_for(f, :payments) do %>
+        <div class="columns is-multiline-mobile is-1 is-variable">
+          <div class="column is-3-desktop is-full-mobile">
+            <label class="label">
+              Date
+            </label>
+            <p class="control">
+              <%= date_input(fp, :date, phx_debounce: "blur", class: "input") %>
+            </p>
+            <%= error_tag(fp, :date) %>
+          </div>
+          <div class="column is-6-desktop is-full-mobile">
+            <label class="label">
+              Notes
+            </label>
+            <p class="control">
+              <%= textarea(fp, :notes, phx_debounce: "blur", class: "textarea", rows: "1") %>
+            </p>
+            <%= error_tag(fp, :notes) %>
 
-      </div>
-      <div class="column is-1-desktop is-full-mobile">  
-        <label class="label">
-          Amount
-        </label>
-        <p class="control">
-          <%= text_input(fp, :virtual_amount, class: "input") %>
-        </p>
-        <%= error_tag(fp, :virtual_amount) %>
-      </div>
-      <div class="column is-narrow-desktop is-full-mobile">  
-        <label class="label is-invisible is-hidden-mobile">
-          invisible
-        </label>
-        <p class="control">
-          <%= link("Remove Line",
-            to: "#",
-            phx_click: "remove_payment",
-            phx_value_payment_id: fp.index,
-            class: "button is-danger is-light is-fullwidth"
-          ) %>
-        </p>
-      </div>
-    </div>
-    <% end %>
+          </div>
+          <div class="column is-1-desktop is-full-mobile">
+            <label class="label">
+              Amount
+            </label>
+            <p class="control">
+              <%= text_input(fp, :virtual_amount, class: "input") %>
+            </p>
+            <%= error_tag(fp, :virtual_amount) %>
+          </div>
+          <div class="column is-narrow-desktop is-full-mobile">
+            <label class="label is-invisible is-hidden-mobile">
+              invisible
+            </label>
+            <p class="control">
+              <%= link("Remove Line",
+                to: "#",
+                phx_click: "remove_payment",
+                phx_value_payment_id: fp.index,
+                class: "button is-danger is-light is-fullwidth"
+              ) %>
+            </p>
+          </div>
+        </div>
+      <% end %>
 
-    <%= link("Add Payment",
-      to: "#",
-      phx_click: "add_payment",
-      class: "button is-dark is-fullwidth column is-2"
-    ) %>
-    <br>
-    <label class="checkbox">
-      <input type="checkbox">
-      Payment collection failed
-    </label>
-  </fieldset>
+      <%= link("Add Payment",
+        to: "#",
+        phx_click: "add_payment",
+        class: "button is-dark is-fullwidth column is-2"
+      ) %>
+      <br>
+      <label class="checkbox">
+        <input type="checkbox">
+        Payment collection failed
+      </label>
+    </fieldset>
   <% end %>
 
   <.live_component

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -96,16 +96,15 @@
           Amount
         </label>
         <p class="control">
-          <%= text_input(fp, :amount, class: "input") %>
+          <%= text_input(fp, :virtual_amount, class: "input") %>
         </p>
-        <%= error_tag(fp, :amount) %>
+        <%= error_tag(fp, :virtual_amount) %>
       </div>
       <div class="column is-narrow-desktop is-full-mobile">  
         <label class="label is-invisible is-hidden-mobile">
           invisible
         </label>
         <p class="control">
-        <% IO.inspect fp.index %>
           <%= link("Remove Line",
             to: "#",
             phx_click: "remove_payment",

--- a/priv/repo/migrations/20220207131403_create_invoices.exs
+++ b/priv/repo/migrations/20220207131403_create_invoices.exs
@@ -54,5 +54,17 @@ defmodule Siwapp.Repo.Migrations.CreateInvoices do
       add :item_id, references(:items, on_delete: :delete_all)
       add :tax_id, references(:taxes, on_delete: :delete_all)
     end
+
+    create table(:payments) do
+      add :date, :date
+      add :amount, :integer
+      add :notes, :text
+      add :deleted_at, :utc_datetime
+      add :invoice_id, references(:invoices, type: :integer, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:payments, [:invoice_id])
   end
 end

--- a/priv/repo/migrations/20220207131403_create_invoices.exs
+++ b/priv/repo/migrations/20220207131403_create_invoices.exs
@@ -59,7 +59,6 @@ defmodule Siwapp.Repo.Migrations.CreateInvoices do
       add :date, :date
       add :amount, :integer
       add :notes, :text
-      add :deleted_at, :utc_datetime
       add :invoice_id, references(:invoices, type: :integer, on_delete: :delete_all)
 
       timestamps()


### PR DESCRIPTION
fixes #272 

- migrations
- schema
- inclusión en el context de Invoices
- funcionando con inputs_for en invoice form. Sólo en edit.

! Se ha creado un módulo Siwapp.Invoices.AmountHelper para agrupar las funciones comunes de Item y Payments relativas al formato de item.unitary_cost / payment.amount

Issues relativos pendientes: #355, #356 