### PR TITLE
error when adding items and taxes in edit solved

### DIFF
--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -107,18 +107,14 @@ defmodule Siwapp.Invoices.Item do
 
   @spec assoc_taxes(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp assoc_taxes(changeset, attrs) do
-    attr_taxes = Map.get(attrs, :taxes) || Map.get(attrs, "taxes", [])
+    attr_taxes = Map.get(attrs, :taxes) || Map.get(attrs, "taxes")
 
-    if associated_taxes?(changeset, attr_taxes) do
-      cast_assoc(changeset, :taxes)
-    else
-      find_taxes(changeset, attr_taxes)
+    cond do
+      attr_taxes -> find_taxes(changeset, attr_taxes)
+      get_field(changeset, :taxes) != [] -> cast_assoc(changeset, :taxes)
+      true -> find_taxes(changeset, [])
     end
   end
-
-  @spec associated_taxes?(Ecto.Changeset.t(), list | map) :: boolean
-  defp associated_taxes?(_changeset, [%Ecto.Changeset{} | _tail]), do: true
-  defp associated_taxes?(changeset, _attr_taxes), do: get_field(changeset, :taxes) != []
 
   @spec find_taxes(Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
   defp find_taxes(changeset, attr_taxes_names) do

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -116,7 +116,7 @@ defmodule Siwapp.Invoices.Item do
     end
   end
 
-  @spec find_taxes(Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
+  @spec find_taxes(Ecto.Changeset.t(), [binary()]) :: Ecto.Changeset.t()
   defp find_taxes(changeset, attr_taxes_names) do
     all_taxes = Commons.list_taxes(:cache)
     all_taxes_names = Enum.map(all_taxes, &String.upcase(&1.name))

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -121,5 +121,4 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     |> Enum.map(fn {item, i} -> {Integer.to_string(i), item} end)
     |> Map.new()
   end
-
 end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -113,6 +113,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     |> assign(:changeset, Invoices.change(invoice, %{"items" => items_from_invoice(invoice)}))
   end
 
+  @spec items_from_invoice(Invoice.t()) :: map()
   defp items_from_invoice(invoice) do
     invoice.items
     |> Enum.map(fn item ->

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -110,21 +110,16 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     |> assign(:action, :edit)
     |> assign(:page_title, invoice.series.code <> "-" <> Integer.to_string(invoice.number))
     |> assign(:invoice, invoice)
-    |> assign(:changeset, Invoices.change(invoice, %{"items" => items_from_invoice(invoice)}))
+    |> assign(:changeset, Invoices.change(invoice, %{"items" => items_as_params(invoice.items)}))
   end
 
-  @spec items_from_invoice(Invoice.t()) :: map()
-  defp items_from_invoice(invoice) do
-    invoice.items
-    |> Enum.map(fn item ->
-      item
-      |> Map.from_struct()
-      |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost])
-      |> Map.put(:taxes, Enum.map(item.taxes, & &1.name))
-      |> SiwappWeb.PageView.atom_keys_to_string()
-    end)
+  @spec items_as_params([Siwapp.Invoices.Item.t()]) :: map()
+  defp items_as_params(items) do
+    items
+    |> Enum.map(&SiwappWeb.PageView.get_item_params/1)
     |> Enum.with_index()
     |> Enum.map(fn {item, i} -> {Integer.to_string(i), item} end)
     |> Map.new()
   end
+
 end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -110,6 +110,20 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     |> assign(:action, :edit)
     |> assign(:page_title, invoice.series.code <> "-" <> Integer.to_string(invoice.number))
     |> assign(:invoice, invoice)
-    |> assign(:changeset, Invoices.change(invoice))
+    |> assign(:changeset, Invoices.change(invoice, %{"items" => items_from_invoice(invoice)}))
+  end
+
+  defp items_from_invoice(invoice) do
+    invoice.items
+    |> Enum.map(fn item ->
+      item
+      |> Map.from_struct()
+      |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost])
+      |> Map.put(:taxes, Enum.map(item.taxes, & &1.name))
+      |> SiwappWeb.PageView.atom_keys_to_string()
+    end)
+    |> Enum.with_index()
+    |> Enum.map(fn {item, i} -> {Integer.to_string(i), item} end)
+    |> Map.new()
   end
 end

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -33,7 +33,7 @@ defmodule SiwappWeb.ItemsComponent do
       |> Enum.count()
       |> Integer.to_string()
 
-    send(self(), {:params_updated, put_in(params, ["items", next_item_index], item_param())})
+    send(self(), {:params_updated, put_in(params, ["items", next_item_index], PageView.get_item_params())})
 
     {:noreply, socket}
   end
@@ -78,11 +78,4 @@ defmodule SiwappWeb.ItemsComponent do
     |> PageView.money_format(Changeset.get_field(changeset, :currency))
   end
 
-  @spec item_param :: map
-  defp item_param do
-    %Item{taxes: Commons.default_taxes_names()}
-    |> Map.from_struct()
-    |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost, :taxes])
-    |> SiwappWeb.PageView.atom_keys_to_string()
-  end
 end

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -5,8 +5,6 @@ defmodule SiwappWeb.ItemsComponent do
 
   alias Ecto.Changeset
   alias Phoenix.HTML.FormData
-  alias Siwapp.Commons
-  alias Siwapp.Invoices.Item
   alias SiwappWeb.PageView
 
   @impl Phoenix.LiveComponent

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -33,7 +33,10 @@ defmodule SiwappWeb.ItemsComponent do
       |> Enum.count()
       |> Integer.to_string()
 
-    send(self(), {:params_updated, put_in(params, ["items", next_item_index], PageView.get_item_params())})
+    send(
+      self(),
+      {:params_updated, put_in(params, ["items", next_item_index], PageView.get_item_params())}
+    )
 
     {:noreply, socket}
   end
@@ -77,5 +80,4 @@ defmodule SiwappWeb.ItemsComponent do
     |> Changeset.get_field(:gross_amount)
     |> PageView.money_format(Changeset.get_field(changeset, :currency))
   end
-
 end

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.ex
@@ -78,7 +78,10 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
     |> assign(:action, :edit)
     |> assign(:page_title, recurring_invoice.name)
     |> assign(:recurring_invoice, recurring_invoice)
-    |> assign(:changeset, RecurringInvoices.change(recurring_invoice))
+    |> assign(
+      :changeset,
+      RecurringInvoices.change(recurring_invoice, %{"items" => recurring_invoice.items})
+    )
   end
 
   # Replicates inputs_for behavior for recurring_invoice's items even when there's no association

--- a/lib/siwapp_web/live/taxes_component.ex
+++ b/lib/siwapp_web/live/taxes_component.ex
@@ -33,32 +33,32 @@ defmodule SiwappWeb.TaxesComponent do
   def render(assigns) do
     ~H"""
     <div class="control msa-wrapper">
-    <%= for {k, _v} <- @selected do %>
-      <input type="hidden" name={"#{@name}[]"} value={k}>
-    <% end %>
-    <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@index}")}>
-      <span class="placeholder"></span>
-      <%= for {k, v} <- @selected do %>
-        <div class="tag-badge">
-          <span>
+      <%= for {k, _v} <- @selected do %>
+        <input type="hidden" name={"#{@name}[]"} value={k}>
+      <% end %>
+      <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@index}")}>
+        <span class="placeholder"></span>
+        <%= for {k, v} <- @selected do %>
+          <div class="tag-badge">
+            <span>
+              <%= k %>
+            </span>
+            <button
+              type="button"
+              phx-click={JS.push("remove", target: @myself, value: %{index: @index, key: k, val: v})}
+            >
+              x
+            </button>
+          </div>
+        <% end %>
+      </div>
+      <ul id={"tag-list-#{@index}"} class="tag-list" style="display: none;">
+        <%= for {k, v} <- not_selected(@options, @selected) do %>
+          <li phx-click={JS.push("add", target: @myself, value: %{index: @index, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@index}")}>
             <%= k %>
-          </span>
-          <button
-            type="button"
-            phx-click={JS.push("remove", target: @myself, value: %{index: @index, key: k, val: v})}
-          >
-            x
-          </button>
-        </div>
-      <% end %>
-    </div>
-    <ul id={"tag-list-#{@index}"} class="tag-list" style="display: none;">
-      <%= for {k, v} <- not_selected(@options, @selected) do %>
-        <li phx-click={JS.push("add", target: @myself, value: %{index: @index, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@index}")}>
-          <%= k %>
-        </li>
-      <% end %>
-    </ul>
+          </li>
+        <% end %>
+      </ul>
     </div>
     """
   end

--- a/lib/siwapp_web/live/taxes_component.ex
+++ b/lib/siwapp_web/live/taxes_component.ex
@@ -33,32 +33,32 @@ defmodule SiwappWeb.TaxesComponent do
   def render(assigns) do
     ~H"""
     <div class="control msa-wrapper">
-      <%= for {k, _v} <- @selected do %>
-        <input type="hidden" id={"hidden_input_#{@name}"} name={"#{@name}[]"} value={k}>
-      <% end %>
-      <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@index}")}>
-        <span class="placeholder"></span>
-        <%= for {k, v} <- @selected do %>
-          <div class="tag-badge">
-            <span>
-              <%= k %>
-            </span>
-            <button
-              type="button"
-              phx-click={JS.push("remove", target: @myself, value: %{index: @index, key: k, val: v})}
-            >
-              x
-            </button>
-          </div>
-        <% end %>
-      </div>
-      <ul id={"tag-list-#{@index}"} class="tag-list" style="display: none;">
-        <%= for {k, v} <- not_selected(@options, @selected) do %>
-          <li phx-click={JS.push("add", target: @myself, value: %{index: @index, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@index}")}>
+    <%= for {k, _v} <- @selected do %>
+      <input type="hidden" name={"#{@name}[]"} value={k}>
+    <% end %>
+    <div class="input input-presentation" phx-click={JS.toggle(to: "#tag-list-#{@index}")}>
+      <span class="placeholder"></span>
+      <%= for {k, v} <- @selected do %>
+        <div class="tag-badge">
+          <span>
             <%= k %>
-          </li>
-        <% end %>
-      </ul>
+          </span>
+          <button
+            type="button"
+            phx-click={JS.push("remove", target: @myself, value: %{index: @index, key: k, val: v})}
+          >
+            x
+          </button>
+        </div>
+      <% end %>
+    </div>
+    <ul id={"tag-list-#{@index}"} class="tag-list" style="display: none;">
+      <%= for {k, v} <- not_selected(@options, @selected) do %>
+        <li phx-click={JS.push("add", target: @myself, value: %{index: @index, key: k, val: v}) |> JS.toggle(to: "#tag-list-#{@index}")}>
+          <%= k %>
+        </li>
+      <% end %>
+    </ul>
     </div>
     """
   end
@@ -79,7 +79,7 @@ defmodule SiwappWeb.TaxesComponent do
       {:params_updated, params}
     )
 
-    {:noreply, assign(socket, selected: selected)}
+    {:noreply, socket}
   end
 
   def handle_event("add", %{"index" => index, "key" => key, "val" => value}, socket) do
@@ -97,7 +97,7 @@ defmodule SiwappWeb.TaxesComponent do
       {:params_updated, params}
     )
 
-    {:noreply, assign(socket, selected: selected)}
+    {:noreply, socket}
   end
 
   @spec not_selected(MapSet.t(), MapSet.t()) :: MapSet.t()

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -2,6 +2,7 @@ defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
   alias Siwapp.Invoices.Item
+  alias Siwapp.Commons
 
   @doc """
   Returns a string of money, which is formed by amount and currency. Options

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -1,8 +1,8 @@
 defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
-  alias Siwapp.Invoices.Item
   alias Siwapp.Commons
+  alias Siwapp.Invoices.Item
 
   @doc """
   Returns a string of money, which is formed by amount and currency. Options

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -1,6 +1,8 @@
 defmodule SiwappWeb.PageView do
   use SiwappWeb, :view
 
+  alias Siwapp.Invoices.Item
+
   @doc """
   Returns a string of money, which is formed by amount and currency. Options
   can be given. Default are [symbol: true, separator: ","]. Check Money.to_string
@@ -12,6 +14,15 @@ defmodule SiwappWeb.PageView do
     |> round()
     |> Money.new(currency)
     |> Money.to_string(options)
+  end
+
+  @spec get_item_params(Item.t()) :: map
+  def get_item_params(item \\ %Item{taxes: Commons.default_taxes_names()}) do
+    item
+    |> Map.from_struct()
+    |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost])
+    |> Map.put(:taxes, Enum.map(item.taxes, & &1.name))
+    |> SiwappWeb.PageView.atom_keys_to_string()
   end
 
   @spec atom_keys_to_string(map) :: map


### PR DESCRIPTION
- fixes #345 

Lo que pasaba era que cuando se monta la LiveView, f.params esta vacío. Como la forma de añadir/eliminar items y añadir/eliminar taxes se basan en la info. de f.params, pues explotaba.

Lo que se ha hecho es rellenar f.params (esto se hace llamando al change con parámetros) con los items que existen en la invoice. Para eso se ha hecho una fn privada, `items_as_params/1`, que transforma los items del invoice (`items: [%Item, %Item...]`) al formato que requieren los parámetros del form (`"items" => %{"0" => %{...}, "1" => %{...} ...`)