### PR TITLE
Rodri/calculate payments

### DIFF
--- a/lib/siwapp/invoices/amount_helper.ex
+++ b/lib/siwapp/invoices/amount_helper.ex
@@ -30,8 +30,13 @@ defmodule Siwapp.Invoices.AmountHelper do
 
       virtual_amount ->
         case Money.parse(virtual_amount, currency) do
-          {:ok, money} -> put_change(changeset, field, money.amount)
-          :error -> add_error(changeset, virtual_field, "Invalid format")
+          {:ok, money} ->
+            changeset
+            |> put_change(field, money.amount)
+            |> put_change(virtual_field, Money.to_decimal(Money.new(money.amount, currency)))
+
+          :error ->
+            add_error(changeset, virtual_field, "Invalid format")
         end
     end
   end

--- a/lib/siwapp/invoices/amount_helper.ex
+++ b/lib/siwapp/invoices/amount_helper.ex
@@ -33,7 +33,7 @@ defmodule Siwapp.Invoices.AmountHelper do
           {:ok, money} ->
             changeset
             |> put_change(field, money.amount)
-            |> put_change(virtual_field, Money.to_decimal(Money.new(money.amount, currency)))
+            |> put_change(virtual_field, Money.to_decimal(money))
 
           :error ->
             add_error(changeset, virtual_field, "Invalid format")

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -134,6 +134,7 @@ defmodule Siwapp.Invoices.Invoice do
     |> validate_length(:contact_person, max: 100)
     |> validate_length(:currency, max: 3)
     |> calculate()
+    |> calculate_payments()
   end
 
   @spec cast_items(Ecto.Changeset.t()) :: Ecto.Changeset.t()
@@ -243,5 +244,30 @@ defmodule Siwapp.Invoices.Invoice do
       nil -> Repo.get(Series, series_id).first_number
       invoice -> invoice.number + 1
     end
+  end
+
+  defp calculate_payments(changeset) do
+    changeset = set_paid_amount(changeset)
+
+    paid_amount = get_field(changeset, :paid_amount)
+    gross_amount = get_field(changeset, :gross_amount)
+
+    if paid_amount >= gross_amount do
+      put_change(changeset, :paid, true)
+    else
+      put_change(changeset, :paid, false)
+    end
+  end
+
+  defp set_paid_amount(changeset) do
+    payments = get_field(changeset, :payments)
+
+    total_payments_amount =
+      payments
+      |> Enum.map(& &1.amount)
+      |> Enum.sum()
+      |> round()
+
+    put_change(changeset, :paid_amount, total_payments_amount)
   end
 end

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -268,7 +268,6 @@ defmodule Siwapp.Invoices.Invoice do
       payments
       |> Enum.map(& &1.amount)
       |> Enum.sum()
-      |> round()
 
     put_change(changeset, :paid_amount, total_payments_amount)
   end

--- a/lib/siwapp/invoices/invoice.ex
+++ b/lib/siwapp/invoices/invoice.ex
@@ -246,6 +246,7 @@ defmodule Siwapp.Invoices.Invoice do
     end
   end
 
+  @spec calculate_payments(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp calculate_payments(changeset) do
     changeset = set_paid_amount(changeset)
 
@@ -259,6 +260,7 @@ defmodule Siwapp.Invoices.Invoice do
     end
   end
 
+  @spec set_paid_amount(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp set_paid_amount(changeset) do
     payments = get_field(changeset, :payments)
 

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -29,7 +29,7 @@ defmodule Siwapp.Invoices.Payment do
     field :date, :date
     field :amount, :integer, default: 0
     field :notes, :string
-    field :virtual_amount, :float, virtual: true
+    field :virtual_amount, :decimal, virtual: true
     belongs_to :invoice, Invoice
 
     timestamps()

--- a/lib/siwapp_web/controllers/iframe_controller.ex
+++ b/lib/siwapp_web/controllers/iframe_controller.ex
@@ -8,7 +8,7 @@ defmodule SiwappWeb.IframeController do
 
   @spec iframe(Plug.Conn.t(), map) :: Plug.Conn.t()
   def iframe(conn, %{"id" => id}) do
-    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :series])
+    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :payments, :series])
     str_template = Templates.print_str_template(invoice)
 
     html(conn, str_template)

--- a/lib/siwapp_web/controllers/page_controller.ex
+++ b/lib/siwapp_web/controllers/page_controller.ex
@@ -12,7 +12,7 @@ defmodule SiwappWeb.PageController do
 
   @spec download(Plug.Conn.t(), map) :: Plug.Conn.t()
   def download(conn, %{"id" => id}) do
-    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :series])
+    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :payments, :series])
     {pdf_content, pdf_name} = Templates.pdf_content_and_name(invoice)
 
     send_download(conn, {:binary, pdf_content}, filename: pdf_name)
@@ -20,7 +20,7 @@ defmodule SiwappWeb.PageController do
 
   @spec send_email(Plug.Conn.t(), map) :: Plug.Conn.t()
   def send_email(conn, %{"id" => id}) do
-    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :series])
+    invoice = Invoices.get!(id, preload: [{:items, :taxes}, :payments, :series])
 
     invoice
     |> Invoices.send_email()

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -2,10 +2,10 @@ defmodule SiwappWeb.InvoicesLive.Edit do
   @moduledoc false
   use SiwappWeb, :live_view
 
+  alias Phoenix.LiveView.JS
   alias Siwapp.Commons
   alias Siwapp.Invoices
   alias Siwapp.Invoices.Invoice
-  alias Phoenix.LiveView.JS
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -63,21 +63,21 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     gross_amount = Ecto.Changeset.get_field(socket.assigns.changeset, :gross_amount)
     paid_amount = Ecto.Changeset.get_field(socket.assigns.changeset, :paid_amount)
 
-    left_amount =
+    virtual_left_amount =
       (gross_amount - paid_amount)
       |> Money.new(currency)
       |> Money.to_decimal()
 
     params =
       if params["payments"] == nil do
-        Map.put(params, "payments", %{"0" => new_payment_params(left_amount)})
+        Map.put(params, "payments", %{"0" => new_payment_params(virtual_left_amount)})
       else
         next_payment_index =
           params["payments"]
           |> Enum.count()
           |> Integer.to_string()
 
-        put_in(params, ["payments", next_payment_index], new_payment_params(left_amount))
+        put_in(params, ["payments", next_payment_index], new_payment_params(virtual_left_amount))
       end
 
     {:noreply, assign(socket, changeset: Invoices.change(socket.assigns.invoice, params))}

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -147,9 +147,8 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     items
     |> Enum.map(fn item ->
       item
-      |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost])
+      |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost, :id])
       |> Map.put(:taxes, Commons.default_taxes_names())
-      |> Mappable.to_map(keys: :strings)
     end)
     |> Enum.with_index()
     |> Enum.map(fn {item, i} -> {Integer.to_string(i), item} end)

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -108,7 +108,6 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
     indexes
     |> Enum.zip(values)
-    |> Enum.into(%{})
     |> Enum.map(fn {k, v} -> {Integer.to_string(k), v} end)
     |> Map.new()
   end

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -21,7 +21,6 @@ defmodule SiwappWeb.InvoicesLive.Edit do
 
   @impl Phoenix.LiveView
   def handle_event("save", %{"invoice" => params}, socket) do
-
     result =
       case socket.assigns.live_action do
         :new -> Invoices.create(params)

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -5,6 +5,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
   alias Siwapp.Commons
   alias Siwapp.Invoices
   alias Siwapp.Invoices.Invoice
+  alias Phoenix.LiveView.JS
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -110,8 +110,7 @@
             <p class="control">
               <%= link("Remove Payment",
                 to: "#",
-                phx_click:
-                  Phoenix.LiveView.JS.push("remove_payment", value: %{params: f.params, payment_id: fp.index}),
+                phx_click: JS.push("remove_payment", value: %{params: f.params, payment_id: fp.index}),
                 class: "button is-danger is-light is-fullwidth"
               ) %>
             </p>
@@ -121,7 +120,7 @@
 
       <%= link("Add Payment",
         to: "#",
-        phx_click: Phoenix.LiveView.JS.push("add_payment", value: %{params: f.params}),
+        phx_click: JS.push("add_payment", value: %{params: f.params}),
         class: "button is-dark is-fullwidth column is-2"
       ) %>
       <br>

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -105,10 +105,10 @@
               invisible
             </label>
             <p class="control">
-              <%= link("Remove Line",
+              <%= link("Remove Payment",
                 to: "#",
-                phx_click: "remove_payment",
-                phx_value_payment_id: fp.index,
+                phx_click:
+                  Phoenix.LiveView.JS.push("remove_payment", value: %{params: f.params, payment_id: fp.index}),
                 class: "button is-danger is-light is-fullwidth"
               ) %>
             </p>
@@ -118,7 +118,7 @@
 
       <%= link("Add Payment",
         to: "#",
-        phx_click: "add_payment",
+        phx_click: Phoenix.LiveView.JS.push("add_payment", value: %{params: f.params}),
         class: "button is-dark is-fullwidth column is-2"
       ) %>
       <br>

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -72,7 +72,9 @@
 
       <%= for fp <- inputs_for(f, :payments) do %>
         <div class="columns is-multiline-mobile is-1 is-variable">
-          <%= hidden_input(fp, :id) %>
+          <%= if fp.data.id do %>
+            <%= hidden_input(fp, :id) %>
+          <% end %>
           <div class="column is-3-desktop is-full-mobile">
             <label class="label">
               Date

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -72,6 +72,7 @@
 
       <%= for fp <- inputs_for(f, :payments) do %>
         <div class="columns is-multiline-mobile is-1 is-variable">
+        <%= hidden_input(fp, :id) %>
           <div class="column is-3-desktop is-full-mobile">
             <label class="label">
               Date

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -72,7 +72,7 @@
 
       <%= for fp <- inputs_for(f, :payments) do %>
         <div class="columns is-multiline-mobile is-1 is-variable">
-        <%= hidden_input(fp, :id) %>
+          <%= hidden_input(fp, :id) %>
           <div class="column is-3-desktop is-full-mobile">
             <label class="label">
               Date

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -44,6 +44,7 @@ defmodule SiwappWeb.ItemsComponent do
       socket.assigns.f.params
       |> pop_in(["items", item_index])
       |> elem(1)
+      |> Map.update!("items", &InvoicesLive.Edit.sort_indexes/1)
 
     send(self(), {:params_updated, params})
 

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -6,6 +6,7 @@ defmodule SiwappWeb.ItemsComponent do
   import SiwappWeb.PageView, only: [money_format: 3, money_format: 2]
 
   alias Ecto.Changeset
+  alias SiwappWeb.InvoicesLive
 
   @impl Phoenix.LiveComponent
   def mount(socket) do

--- a/lib/siwapp_web/live/items_component.html.heex
+++ b/lib/siwapp_web/live/items_component.html.heex
@@ -1,7 +1,9 @@
 <div>
   <%= for fi <- @inputs_for do %>
     <div class="columns is-multiline-mobile is-1 is-variable">
-      <%= hidden_input(fi, :id) %>
+      <%= if fi.data.id do %>
+        <%= hidden_input(fi, :id) %>
+      <% end %>
       <div class="column is-4-desktop is-full-mobile">
         <%= label(fi, :description, class: "label") %>
         <p class="control">

--- a/lib/siwapp_web/live/items_component.html.heex
+++ b/lib/siwapp_web/live/items_component.html.heex
@@ -1,6 +1,7 @@
 <div>
   <%= for fi <- @inputs_for do %>
     <div class="columns is-multiline-mobile is-1 is-variable">
+      <%= hidden_input(fi, :id) %>
       <div class="column is-4-desktop is-full-mobile">
         <%= label(fi, :description, class: "label") %>
         <p class="control">

--- a/lib/siwapp_web/resolvers/invoice.ex
+++ b/lib/siwapp_web/resolvers/invoice.ex
@@ -57,7 +57,7 @@ defmodule SiwappWeb.Resolvers.Invoice do
 
   @spec delete(map(), Absinthe.Resolution.t()) :: {:error, map()} | {:ok, Invoices.Invoice.t()}
   def delete(%{id: id}, _resolution) do
-    invoice = Invoices.get(id, preload: [{:items, :taxes}])
+    invoice = Invoices.get(id, preload: [{:items, :taxes}, :payments])
 
     if is_nil(invoice) do
       {:error, message: "Failed!", details: "Invoice not found"}

--- a/lib/siwapp_web/templates/page/invoices_table.html.heex
+++ b/lib/siwapp_web/templates/page/invoices_table.html.heex
@@ -100,7 +100,7 @@
               </span>
             </td>
             <td>
-              <%= money_format(invoice.gross_amount, invoice.currency) %>
+              <%= money_format(invoice.gross_amount - invoice.paid_amount, invoice.currency) %>
             </td>
 
           <% :past_due -> %>
@@ -110,7 +110,7 @@
               </span>
             </td>
             <td>
-              <%= money_format(invoice.gross_amount, invoice.currency) %>
+              <%= money_format(invoice.gross_amount - invoice.paid_amount, invoice.currency) %>
             </td>
         <% end %>
 

--- a/test/support/fixtures/invoices_fixtures.ex
+++ b/test/support/fixtures/invoices_fixtures.ex
@@ -37,6 +37,6 @@ defmodule Siwapp.InvoicesFixtures do
       |> valid_invoice_attributes()
       |> Invoices.create()
 
-    Repo.preload(invoice, [:customer, {:items, :taxes}, :series])
+    Repo.preload(invoice, [:customer, {:items, :taxes}, :payments, :series])
   end
 end


### PR DESCRIPTION
Se han añadido las funciones de los cálculos de los payments. 
También se ha cambiado la forma en la que se trabaja con los payments haciendo que funcionen como los items. Así, cuando se añade un payment se crean de cero sus params por defecto y luego estos se insertan el los params globales y luego  se pasa todo esto por el changeset para que esté disponible para el formulario.

También ha habido que hacer una función que reindexe los payments. De tal forma que si se tiene el 0, 1 y 2, y eliminamos el 1.
el 0 sigue siendo el 0 y el 2 pasa a ser el 1