### PR TITLE
Botones de send y download en edit

### DIFF
--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -149,9 +149,10 @@
       <% end %>
       <%= live_redirect("Back", to: Routes.invoices_index_path(@socket, :index), class: "button is-dark") %>
       <%= if @live_action == :edit do %>
-        <button class="button is-info">
-          Send Email
-        </button>
+        <%= link("Send Email",
+          to: Routes.page_path(@socket, :send_email, @invoice.id),
+          class: "button is-purple"
+        ) %>
         <%= link("Download PDF",
           to: Routes.page_path(@socket, :download, @invoice.id),
           class: "button is-info"

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -122,10 +122,7 @@
         class: "button is-dark is-fullwidth column is-2"
       ) %>
       <br>
-      <label class="checkbox">
-        <input type="checkbox">
-        Payment collection failed
-      </label>
+      <%= checkbox(f, :failed, class: "checkbox") %> Payment collection failed
     </fieldset>
   <% end %>
 


### PR DESCRIPTION
Actualmente los botones de "Send Email" y "Download PDF" en la vista de editar facturas funciona como en Siwapp Demo, es decir, no responden ante cambios en la factura, utilizan la factura que está en base de datos. 

También funciona ahora el checkbox "Payment collection failed"

Pd: El botón de enviar la factura por correo está en violeta porque así lo puse ya en la vista del iframe y, dado que hacen lo mismo, pensaba que deberían tener el mismo color. Creé ese botón violeta para tener un poco de variedad y que no hubiera tantos botones azules seguidos pero, si no gusta, se puede cambiar el otro.