### PR TITLE
Nurietzsche/refactor calculos

### DIFF
--- a/lib/siwapp/invoice_helper.ex
+++ b/lib/siwapp/invoice_helper.ex
@@ -83,40 +83,38 @@ defmodule Siwapp.InvoiceHelper do
 
   @spec set_net_amount(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp set_net_amount(changeset) do
-    items = get_field(changeset, :items)
-
     total_net_amount =
-      items
+      changeset
+      |> get_field(:items)
       |> Enum.map(& &1.net_amount)
       |> Enum.sum()
-      |> round()
 
     put_change(changeset, :net_amount, total_net_amount)
   end
 
   @spec set_taxes_amounts(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp set_taxes_amounts(changeset) do
-    items = get_field(changeset, :items)
-
     total_taxes_amounts =
-      items
+      changeset
+      |> get_field(:items)
       |> Enum.map(& &1.taxes_amount)
-      |> Enum.reduce(%{}, &Map.merge(&1, &2, fn _, v1, v2 -> v1 + v2 end))
+      |> Enum.reduce(%{}, &Map.merge(&1, &2, fn _, v1, v2 -> Decimal.add(v1, v2) end))
+      |> Enum.map(fn {k, v} -> {k, v |> Decimal.round() |> Decimal.to_integer()} end)
+      |> Map.new()
 
     put_change(changeset, :taxes_amounts, total_taxes_amounts)
   end
 
   @spec set_gross_amount(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp set_gross_amount(changeset) do
-    net_amount = get_field(changeset, :net_amount)
-
-    tax_amount = get_field(changeset, :taxes_amounts)
-
     taxes_amount =
-      tax_amount
+      changeset
+      |> get_field(:taxes_amounts)
       |> Map.values()
       |> Enum.sum()
 
-    put_change(changeset, :gross_amount, round(net_amount + taxes_amount))
+    gross_amount = get_field(changeset, :net_amount) + taxes_amount
+
+    put_change(changeset, :gross_amount, gross_amount)
   end
 end

--- a/lib/siwapp/invoices/payment.ex
+++ b/lib/siwapp/invoices/payment.ex
@@ -42,7 +42,6 @@ defmodule Siwapp.Invoices.Payment do
     |> assign_date()
     |> set_amount(:amount, :virtual_amount, currency)
     |> foreign_key_constraint(:invoice_id)
-    |> set_virtual_amount(:amount, :virtual_amount, currency)
   end
 
   @spec assign_date(Ecto.Changeset.t()) :: Ecto.Changeset.t()

--- a/lib/siwapp_web/live/home_live/index.ex
+++ b/lib/siwapp_web/live/home_live/index.ex
@@ -3,6 +3,8 @@ defmodule SiwappWeb.HomeLive.Index do
   This module manages the LiveView events from the homepage
   """
   use SiwappWeb, :live_view
+
+  import SiwappWeb.PageView, only: [money_format: 3]
   alias Siwapp.Invoices
   alias SiwappWeb.GraphicHelpers
 
@@ -26,8 +28,7 @@ defmodule SiwappWeb.HomeLive.Index do
     Invoices.Statistics.get_amount_per_day()
     |> Enum.map(fn {date, amount} -> {NaiveDateTime.new!(date, ~T[00:00:00]), amount} end)
     |> GraphicHelpers.line_plot(
-      y_formatter:
-        &SiwappWeb.PageView.money_format(&1, "USD", symbol: false, fractional_unit: false)
+      y_formatter: &money_format(round(&1), "USD", symbol: false, fractional_unit: false)
     )
   end
 

--- a/lib/siwapp_web/live/invoices_live/header_component.ex
+++ b/lib/siwapp_web/live/invoices_live/header_component.ex
@@ -2,9 +2,10 @@ defmodule SiwappWeb.InvoicesLive.HeaderComponent do
   @moduledoc false
   use SiwappWeb, :live_component
 
+  import SiwappWeb.PageView, only: [money_format: 2, money_format: 3]
+
   alias Siwapp.Invoices.Statistics
   alias SiwappWeb.GraphicHelpers
-  alias SiwappWeb.PageView
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
@@ -49,11 +50,11 @@ defmodule SiwappWeb.InvoicesLive.HeaderComponent do
         >
           <div class="card-header-content m-3">
             <div class="card-header-title has-text-weight-bold p-0">
-              <%= PageView.money_format(@default_total, @default_currency) %>
+              <%= money_format(@default_total, @default_currency) %>
             </div>
             <%= for {currency, total} <- @other_totals do %>
               <div class="card-header-title has-text-weight-medium p-0">
-                <%= PageView.money_format(total, currency) %>
+                <%= money_format(total, currency) %>
               </div>
             <% end %>
           </div>
@@ -90,7 +91,7 @@ defmodule SiwappWeb.InvoicesLive.HeaderComponent do
     invoices_data
     |> Enum.map(fn {date, amount} -> {NaiveDateTime.new!(date, ~T[00:00:00]), amount} end)
     |> GraphicHelpers.line_plot(
-      y_formatter: &PageView.money_format(&1, "USD", symbol: false, fractional_unit: false)
+      y_formatter: &money_format(round(&1), "USD", symbol: false, fractional_unit: false)
     )
   end
 

--- a/lib/siwapp_web/live/items_component.ex
+++ b/lib/siwapp_web/live/items_component.ex
@@ -3,9 +3,9 @@ defmodule SiwappWeb.ItemsComponent do
 
   use SiwappWeb, :live_component
 
+  import SiwappWeb.PageView, only: [money_format: 3, money_format: 2]
+
   alias Ecto.Changeset
-  alias Phoenix.HTML.FormData
-  alias SiwappWeb.PageView
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
@@ -48,35 +48,6 @@ defmodule SiwappWeb.ItemsComponent do
     send(self(), {:params_updated, params})
 
     {:noreply, socket}
-  end
-
-  @spec item_net_amount(Changeset.t(), FormData.t()) :: binary
-  defp item_net_amount(changeset, currency) do
-    value = Changeset.get_field(changeset, :net_amount)
-    PageView.money_format(value, currency, symbol: false, separator: "")
-  end
-
-  @spec net_amount(Ecto.Changeset.t()) :: binary
-  defp net_amount(changeset) do
-    changeset
-    |> Changeset.get_field(:net_amount)
-    |> PageView.money_format(Changeset.get_field(changeset, :currency))
-  end
-
-  @spec taxes_amounts(Ecto.Changeset.t()) :: list
-  defp taxes_amounts(changeset) do
-    changeset
-    |> Changeset.get_field(:taxes_amounts)
-    |> Enum.map(fn {k, v} ->
-      {k, PageView.money_format(v, Changeset.get_field(changeset, :currency))}
-    end)
-  end
-
-  @spec gross_amount(Ecto.Changeset.t()) :: binary
-  defp gross_amount(changeset) do
-    changeset
-    |> Changeset.get_field(:gross_amount)
-    |> PageView.money_format(Changeset.get_field(changeset, :currency))
   end
 
   @spec item_params() :: map

--- a/lib/siwapp_web/live/items_component.html.heex
+++ b/lib/siwapp_web/live/items_component.html.heex
@@ -48,7 +48,7 @@
         </label>
         <p class="control">
           <a class="button is-static is-fullwidth">
-            <%= item_net_amount(fi.source, @currency) %>
+            <%= money_format(input_value(fi, :net_amount), @currency, symbol: false) %>
           </a>
         </p>
       </div>
@@ -83,23 +83,23 @@
           <tr>
             <th>Subtotal:</th>
             <td>
-              <%= net_amount(@changeset) %>
+              <%= money_format(input_value(@f, :net_amount), @currency) %>
             </td>
           </tr>
-          <%= for {tax_name, tax_value} <- taxes_amounts(@changeset) do %>
+          <%= for {tax_name, tax_value} <- input_value(@f, :taxes_amounts) do %>
             <tr>
               <th>
                 <%= tax_name %>
               </th>
               <td>
-                <%= tax_value %>
+                <%= money_format(tax_value, @currency) %>
               </td>
             </tr>
           <% end %>
           <tr>
             <th>TOTAL</th>
             <td>
-              <%= gross_amount(@changeset) %>
+              <%= money_format(input_value(@f, :gross_amount), @currency) %>
             </td>
           </tr>
         </tbody>

--- a/lib/siwapp_web/views/page_view.ex
+++ b/lib/siwapp_web/views/page_view.ex
@@ -9,7 +9,6 @@ defmodule SiwappWeb.PageView do
   @spec money_format(number, atom | binary, keyword) :: binary
   def money_format(value, currency, options \\ []) do
     value
-    |> round()
     |> Money.new(currency)
     |> Money.to_string(options)
   end

--- a/test/siwapp/invoices/invoice_test.exs
+++ b/test/siwapp/invoices/invoice_test.exs
@@ -121,28 +121,30 @@ defmodule Siwapp.InvoiceTest do
       assert invoice.gross_amount == 0
     end
 
-    test "Total net amount is the rounded sum of the net amounts of each item", %{
-      invoice: invoice
-    } do
-      # 133-(133*(10/100)) = 119.70 (net_amount per item)
-      # 119.70*2 = 239.40 (total net_amount)
-      assert invoice.net_amount == 239
+    test "Total net amount is the sum of the net amounts of each item (which are already rounded)",
+         %{
+           invoice: invoice
+         } do
+      # 133-(133*(10/100)) = 120 (net_amount per item)
+      # 120*2 = 240 (total net_amount)
+      assert invoice.net_amount == 240
     end
 
-    test "Total taxes amounts is a map with the total amount per tax", %{invoice: invoice} do
-      # 119.70 (net_amount per item)
-      # 119.70*(21/100) = 25.137 (VAT per item)
-      # 119.70*(-15/100) = -17.955 (RETENTION for 2nd item)
-      assert invoice.taxes_amounts == %{"RETENTION" => -17.955, "VAT" => 50.274}
+    test "Total taxes amounts is a map with the total amount per tax (which are already rounded)",
+         %{invoice: invoice} do
+      # 120 (net_amount per item)
+      # 120*(21/100) = 25 (VAT per item)
+      # 120*(-15/100) = -18 (RETENTION for 2nd item)
+      assert invoice.taxes_amounts == %{"RETENTION" => -18, "VAT" => 50}
     end
 
-    test "Total gross amount is the rounded sum of the total net amount and the taxes amounts", %{
+    test "Total gross amount is the sum of the total net amount and the taxes amounts", %{
       invoice: invoice
     } do
       # 239 (total net_amount)
       # %{"RETENTION" => -17.955, "VAT" => 50.274} (total taxes amounts)
       # 239 + 50.274 - 17.955 = 271.319 (total gross_amount)
-      assert invoice.gross_amount == 271
+      assert invoice.gross_amount == 272
     end
   end
 


### PR DESCRIPTION
fixes #393 

Los tests fallaban porque los redondeos ahora se hacen en un momento diferente siguiendo el blog del PR de @peillis y ya están arreglados. Los chart fallaban porque el formatter usa como valores de entrada floats que hay que redondear.