### PR TITLE
Pablo/search save query

### DIFF
--- a/lib/siwapp/customers.ex
+++ b/lib/siwapp/customers.ex
@@ -18,9 +18,9 @@ defmodule Siwapp.Customers do
   @doc """
   Lists customers in database following CustomerQuery.list_with_assoc_invoice_fields/2 query
   """
-  @spec list_with_assoc_invoice_fields(non_neg_integer(), non_neg_integer()) :: [Customer.t()]
-  def list_with_assoc_invoice_fields(limit \\ 100, offset \\ 0),
-    do: Repo.all(CustomerQuery.list_with_assoc_invoice_fields(limit, offset))
+  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) :: [Customer.t()]
+  def list_with_assoc_invoice_fields(query, limit \\ 100, offset \\ 0),
+    do: Repo.all(CustomerQuery.list_with_assoc_invoice_fields(query, limit, offset))
 
   @spec suggest_by_name(binary | nil, keyword()) :: list
   def suggest_by_name(name, options \\ [])

--- a/lib/siwapp/customers.ex
+++ b/lib/siwapp/customers.ex
@@ -18,7 +18,8 @@ defmodule Siwapp.Customers do
   @doc """
   Lists customers in database following CustomerQuery.list_with_assoc_invoice_fields/2 query
   """
-  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) :: [Customer.t()]
+  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) ::
+          [Customer.t()]
   def list_with_assoc_invoice_fields(query, limit \\ 100, offset \\ 0),
     do: Repo.all(CustomerQuery.list_with_assoc_invoice_fields(query, limit, offset))
 

--- a/lib/siwapp/customers/customer_query.ex
+++ b/lib/siwapp/customers/customer_query.ex
@@ -23,7 +23,8 @@ defmodule Siwapp.Customers.CustomerQuery do
   paid and currencies (sum of gross amount, sum of paid amount and list of
   all currencies, respectively, used in all invoices associated to customer)
   """
-  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) :: Ecto.Query.t()
+  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) ::
+          Ecto.Query.t()
   def list_with_assoc_invoice_fields(query, limit, offset) do
     query
     |> from(as: :query)

--- a/lib/siwapp/customers/customer_query.ex
+++ b/lib/siwapp/customers/customer_query.ex
@@ -23,15 +23,19 @@ defmodule Siwapp.Customers.CustomerQuery do
   paid and currencies (sum of gross amount, sum of paid amount and list of
   all currencies, respectively, used in all invoices associated to customer)
   """
-  @spec list_with_assoc_invoice_fields(non_neg_integer(), non_neg_integer()) :: Ecto.Query.t()
-  def list_with_assoc_invoice_fields(limit, offset) do
-    limit
-    |> list(offset)
-    |> join(:left, [c], i in Siwapp.Invoices.Invoice,
-      on: c.id == i.customer_id and not (i.draft or i.failed)
+  @spec list_with_assoc_invoice_fields(Ecto.Queryable.t(), non_neg_integer(), non_neg_integer()) :: Ecto.Query.t()
+  def list_with_assoc_invoice_fields(query, limit, offset) do
+    query
+    |> from(as: :query)
+    |> order_by(desc: :id)
+    |> limit(^limit)
+    |> offset(^offset)
+    |> join(:left, [query: c], i in Siwapp.Invoices.Invoice,
+      on: c.id == i.customer_id and not (i.draft or i.failed),
+      as: :inv
     )
-    |> group_by([c, i], c.id)
-    |> select([c, i], %Customer{
+    |> group_by([query: c], c.id)
+    |> select([query: c, inv: i], %Customer{
       total: coalesce(sum(i.gross_amount), 0),
       paid: coalesce(sum(i.paid_amount), 0),
       currencies: fragment("COALESCE(NULLIF(array_agg(?), '{NULL}'), '{}')", i.currency),

--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -2,6 +2,7 @@ defmodule Siwapp.Searches do
   @moduledoc """
   Search Context
   """
+  import Ecto.Query
   alias Siwapp.Customers.CustomerQuery
   alias Siwapp.Query
   alias Siwapp.Repo
@@ -15,22 +16,23 @@ defmodule Siwapp.Searches do
   @doc """
   Filter invoices, customers or recurring_invoices by the selected parameters
   """
-  @spec filters(Ecto.Queryable.t(), [{binary, binary}]) :: [type_of_struct()]
-  def filters(Siwapp.Customers.Customer = customer, params) do
-    params
-    |> Enum.reduce(customer, fn {key, value}, acc_query ->
-      SearchQuery.filter_by(acc_query, key, value)
-    end)
+  @spec filters(Ecto.Queryable.t(), keyword()) :: [type_of_struct()]
+  def filters(query, options \\ []) do
+    default = [limit: 20, offset: 0, preload: []]
+    options = Keyword.merge(default, options)
+
+    query
+    |> limit(^options[:limit])
+    |> offset(^options[:offset])
+    |> Query.list_preload(options[:preload])
     |> Repo.all()
   end
 
-  def filters(query, params) do
-    params
-    |> Enum.reduce(query, fn {key, value}, acc_query ->
+  @spec filters_query(Ecto.Queryable.t(), [{binary, binary}]) :: Ecto.Queryable.t()
+  def filters_query(query, params) do
+    Enum.reduce(params, query, fn {key, value}, acc_query ->
       SearchQuery.filter_by(acc_query, key, value)
     end)
-    |> Query.list_preload(:series)
-    |> Repo.all()
   end
 
   @spec get_customers_names(binary, non_neg_integer) :: list()

--- a/lib/siwapp_web/live/customers_live/index.ex
+++ b/lib/siwapp_web/live/customers_live/index.ex
@@ -17,7 +17,8 @@ defmodule SiwappWeb.CustomersLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(customers: Customers.list_with_assoc_invoice_fields(20, 0))
+     |> assign(:query, Customer)
+     |> assign(customers: Customers.list_with_assoc_invoice_fields(Customer, 20, 0))
      |> assign(page_title: "Customers")}
   end
 
@@ -43,9 +44,13 @@ defmodule SiwappWeb.CustomersLive.Index do
 
   @impl Phoenix.LiveView
   def handle_info({:search, params}, socket) do
-    customers = Searches.filters(Customer, params)
+    query = Searches.filters_query(Customer, params)
+    customers = Customers.list_with_assoc_invoice_fields(query, 20)
 
-    {:noreply, assign(socket, :customers, customers)}
+    {:noreply,
+      socket
+      |> assign(:query, query)
+      |> assign(:customers, customers)}
   end
 
   @spec due(integer, integer) :: integer

--- a/lib/siwapp_web/live/customers_live/index.ex
+++ b/lib/siwapp_web/live/customers_live/index.ex
@@ -18,7 +18,7 @@ defmodule SiwappWeb.CustomersLive.Index do
      socket
      |> assign(:page, 0)
      |> assign(:query, Customer)
-     |> assign(customers: Customers.list_with_assoc_invoice_fields(Customer, 20, 0))
+     |> assign(customers: Customers.list_with_assoc_invoice_fields(Customer, 20))
      |> assign(page_title: "Customers")}
   end
 
@@ -26,13 +26,15 @@ defmodule SiwappWeb.CustomersLive.Index do
   def handle_event("load-more", _, socket) do
     %{
       page: page,
-      customers: customers
+      customers: customers,
+      query: query
     } = socket.assigns
 
     {
       :noreply,
       assign(socket,
-        customers: customers ++ Customers.list_with_assoc_invoice_fields(20, (page + 1) * 20),
+        customers:
+          customers ++ Customers.list_with_assoc_invoice_fields(query, 20, (page + 1) * 20),
         page: page + 1
       )
     }
@@ -48,9 +50,9 @@ defmodule SiwappWeb.CustomersLive.Index do
     customers = Customers.list_with_assoc_invoice_fields(query, 20)
 
     {:noreply,
-      socket
-      |> assign(:query, query)
-      |> assign(:customers, customers)}
+     socket
+     |> assign(:query, query)
+     |> assign(:customers, customers)}
   end
 
   @spec due(integer, integer) :: integer

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -41,30 +41,6 @@ defmodule SiwappWeb.InvoicesLive.Index do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("load-more", _, %{live_action: :customer} = socket) do
-    %{
-      page: page,
-      invoices: invoices,
-      customer_id: customer_id
-    } = socket.assigns
-
-    more_invoices =
-      Invoices.list(
-        filters: [{:customer_id, customer_id}],
-        preload: :series,
-        limit: 20,
-        offset: (page + 1) * 20
-      )
-
-    {
-      :noreply,
-      assign(socket,
-        invoices: invoices ++ more_invoices,
-        page: page + 1
-      )
-    }
-  end
-
   def handle_event("load-more", _, socket) do
     %{
       page: page,

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -68,14 +68,15 @@ defmodule SiwappWeb.InvoicesLive.Index do
   def handle_event("load-more", _, socket) do
     %{
       page: page,
-      invoices: invoices
+      invoices: invoices,
+      query: query
     } = socket.assigns
 
     {
       :noreply,
       assign(socket,
         invoices:
-          invoices ++ Invoices.list(limit: 20, offset: (page + 1) * 20, preload: [:series]),
+          invoices ++ Searches.filters(query, offset: (page + 1) * 20, preload: [:series]),
         page: page + 1
       )
     }
@@ -117,9 +118,9 @@ defmodule SiwappWeb.InvoicesLive.Index do
     invoices = Searches.filters(query, preload: [:series])
 
     {:noreply,
-      socket
-      |> assign(:query, query)
-      |> assign(:invoices, invoices)}
+     socket
+     |> assign(:query, query)
+     |> assign(:invoices, invoices)}
   end
 
   @spec update_checked(map(), Phoenix.LiveView.Socket.t()) :: MapSet.t()

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -113,9 +113,13 @@ defmodule SiwappWeb.InvoicesLive.Index do
 
   @impl Phoenix.LiveView
   def handle_info({:search, params}, socket) do
-    invoices = Searches.filters(Invoice, params)
+    query = Searches.filters_query(Invoice, params)
+    invoices = Searches.filters(query, preload: [:series])
 
-    {:noreply, assign(socket, :invoices, invoices)}
+    {:noreply,
+      socket
+      |> assign(:query, query)
+      |> assign(:invoices, invoices)}
   end
 
   @spec update_checked(map(), Phoenix.LiveView.Socket.t()) :: MapSet.t()

--- a/lib/siwapp_web/live/recurring_invoices_live/index.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/index.ex
@@ -55,9 +55,13 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
 
   @impl Phoenix.LiveView
   def handle_info({:search, params}, socket) do
-    recurring_invoices = Searches.filters(RecurringInvoice, params)
+    query = Searches.filters_query(RecurringInvoice, params)
+    recurring_invoices = Searches.filters(query, preload: [:series])
 
-    {:noreply, assign(socket, :recurring_invoices, recurring_invoices)}
+    {:noreply,
+      socket
+      |> assign(:query, query)
+      |> assign(:recurring_invoices, recurring_invoices)}
   end
 
   @spec update_checked(map(), Phoenix.LiveView.Socket.t()) :: MapSet.t()

--- a/lib/siwapp_web/live/recurring_invoices_live/index.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/index.ex
@@ -12,6 +12,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
+     |> assign(:query, RecurringInvoice)
      |> assign(
        :recurring_invoices,
        RecurringInvoices.list(limit: 20, offset: 0, preload: [:series])
@@ -24,7 +25,8 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
   def handle_event("load-more", _, socket) do
     %{
       page: page,
-      recurring_invoices: recurring_invoices
+      recurring_invoices: recurring_invoices,
+      query: query
     } = socket.assigns
 
     {
@@ -32,7 +34,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
       assign(socket,
         recurring_invoices:
           recurring_invoices ++
-            RecurringInvoices.list(limit: 20, offset: (page + 1) * 20, preload: [:series]),
+            Searches.filters(query, offset: (page + 1) * 20, preload: [:series]),
         page: page + 1
       )
     }
@@ -59,9 +61,9 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
     recurring_invoices = Searches.filters(query, preload: [:series])
 
     {:noreply,
-      socket
-      |> assign(:query, query)
-      |> assign(:recurring_invoices, recurring_invoices)}
+     socket
+     |> assign(:query, query)
+     |> assign(:recurring_invoices, recurring_invoices)}
   end
 
   @spec update_checked(map(), Phoenix.LiveView.Socket.t()) :: MapSet.t()


### PR DESCRIPTION
En este pr lo que se ha hecho es guardarse en el socket la query que se usa para filtrar. Con ella, al hacer scroll se renderizan los 20 siguientes datos pero no de la tabla de invoices, de customers o de recurring_invoices, si no de la query que tenga el socket.