### PR TITLE
Only free customers and series can be deleted

### DIFF
--- a/lib/siwapp/commons.ex
+++ b/lib/siwapp/commons.ex
@@ -159,14 +159,17 @@ defmodule Siwapp.Commons do
         # because that series is the default one
 
   """
-  @spec delete_series(Series.t()) :: {:ok, Series.t()} | {:error, any()}
+  @spec delete_series(Series.t()) :: {:ok, Series.t()} | {:error, binary}
   def delete_series(%Series{} = series) do
-    if get_default_series() == series do
+    if series.default do
       {:error, "The series you're aiming to delete is the default series. \
-      Change the default series first with change_default_series/1 function."}
+      Change the default series first"}
     else
       Repo.delete(series)
     end
+  rescue
+    _e in Ecto.ConstraintError ->
+      {:error, "It's forbidden to delete a series with associated invoices"}
   end
 
   @doc """

--- a/lib/siwapp/customers.ex
+++ b/lib/siwapp/customers.ex
@@ -65,7 +65,8 @@ defmodule Siwapp.Customers do
   def delete(%Customer{} = customer) do
     Repo.delete(customer)
   rescue
-    e in Ecto.ConstraintError -> {:error, e.message}
+    _e in Ecto.ConstraintError ->
+      {:error, "It's forbidden to delete a customer with associated invoices/recurring invoices"}
   end
 
   @doc """

--- a/lib/siwapp_web/live/customers_live/edit.ex
+++ b/lib/siwapp_web/live/customers_live/edit.ex
@@ -47,14 +47,17 @@ defmodule SiwappWeb.CustomersLive.Edit do
   end
 
   def handle_event("delete", _params, socket) do
-    Customers.delete(socket.assigns.customer)
+    {:noreply,
+     socket.assigns.customer
+     |> Customers.delete()
+     |> case do
+       {:ok, _} ->
+         put_flash(socket, :info, "Customer succesfully deleted")
 
-    socket =
-      socket
-      |> put_flash(:info, "Customer succesfully deleted")
-      |> push_redirect(to: Routes.customers_index_path(socket, :index))
-
-    {:noreply, socket}
+       {:error, msg} ->
+         put_flash(socket, :error, msg)
+     end
+     |> push_redirect(to: Routes.customers_index_path(socket, :index))}
   end
 
   def handle_event("copy", _params, socket) do

--- a/lib/siwapp_web/live/series_live/form_component.ex
+++ b/lib/siwapp_web/live/series_live/form_component.ex
@@ -41,8 +41,8 @@ defmodule SiwappWeb.SeriesLive.FormComponent do
          |> put_flash(:info, "Series was successfully destroyed.")
          |> push_redirect(to: socket.assigns.return_to)}
 
-      {:error, _msg} ->
-        {:noreply, put_flash(socket, :error, "You can't delete the default series.")}
+      {:error, msg} ->
+        {:noreply, put_flash(socket, :error, msg)}
     end
   end
 


### PR DESCRIPTION
Si una serie tiene facturas asociadas o un cliente (en este caso también
se consideran las recurrentes), entonces no pueden ser eliminados (eso
ya es la opción por defecto de la migración on_delete: :restrict). Lo
que he hecho simplemente es capturar el error y mostrar el mensaje
adecuadamente en las vistas

fixes #394