### PR TITLE
fix taxes changes

### DIFF
--- a/lib/siwapp/commons.ex
+++ b/lib/siwapp/commons.ex
@@ -4,6 +4,7 @@ defmodule Siwapp.Commons do
   """
 
   import Ecto.Query, warn: false
+  import Siwapp.Query
 
   alias Siwapp.Commons.Series
   alias Siwapp.Commons.Tax
@@ -279,6 +280,8 @@ defmodule Siwapp.Commons do
   """
   @spec get_tax!(non_neg_integer) :: Tax.t()
   def get_tax!(id), do: Repo.get!(Tax, id)
+
+  def get_tax(name), do: by(Tax, :name, name) |> Repo.one()
 
   @doc """
   Creates a tax.

--- a/lib/siwapp/commons/tax.ex
+++ b/lib/siwapp/commons/tax.ex
@@ -36,5 +36,14 @@ defmodule Siwapp.Commons.Tax do
     |> unique_constraint([:name, :enabled])
     |> validate_required([:name, :value])
     |> validate_length(:name, max: 50)
+    |> maybe_upcase_name()
+  end
+
+  def maybe_upcase_name(changeset) do
+    if name = get_field(changeset, :name) do
+      put_change(changeset, :name, String.upcase(name))
+    else
+      changeset
+    end
   end
 end

--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -131,11 +131,6 @@ defmodule Siwapp.Invoices do
       |> Query.not_deleted()
       |> Repo.get!(id)
       |> Repo.preload(list)
-
-    items_with_calculations =
-      Enum.map(invoice.items, &Ecto.Changeset.apply_changes(change_item(&1, invoice.currency)))
-
-    Map.put(invoice, :items, items_with_calculations)
   end
 
   @doc """

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -101,37 +101,38 @@ defmodule Siwapp.Invoices.Item do
   # we cast it and that's it. If it actually doesn't, we find the taxes associated
   # in the attributes. If the attributes have a tax that it doesn't exist we add
   # an error in the changeset.
-
   @spec assoc_taxes(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp assoc_taxes(changeset, attrs) do
-    attr_taxes = Map.get(attrs, :taxes) || Map.get(attrs, "taxes")
+    attr_taxes = MapSet.new(get(attrs, :taxes) || [], &String.upcase/1)
+    current_taxes = MapSet.new(get_field(changeset, :taxes) || [], &(&1.name))
+    new_taxes = MapSet.difference(attr_taxes, current_taxes)
 
     cond do
-      attr_taxes -> find_taxes(changeset, attr_taxes)
-      get_field(changeset, :taxes) != [] -> cast_assoc(changeset, :taxes)
-      true -> find_taxes(changeset, [])
+      MapSet.equal?(attr_taxes, current_taxes) -> changeset
+      MapSet.subset?(attr_taxes, current_taxes) -> put_taxes(changeset, attr_taxes)
+      true -> put_taxes(changeset, new_taxes)
     end
   end
 
-  @spec find_taxes(Ecto.Changeset.t(), [binary()]) :: Ecto.Changeset.t()
-  defp find_taxes(changeset, attr_taxes_names) do
-    all_taxes = Commons.list_taxes(:cache)
-    all_taxes_names = Enum.map(all_taxes, &String.upcase(&1.name))
+  @spec put_taxes(Ecto.Changeset.t(), [MapSet.t()]) :: Ecto.Changeset.t()
+  defp put_taxes(changeset, taxes) do
+    all_taxes = MapSet.new(Commons.list_taxes(:cache) || [], &(&1.name))
+    changeset = Enum.reduce(taxes, changeset, &check_wrong_taxes(&1, &2, all_taxes))
 
-    attr_taxes_names = Enum.map(attr_taxes_names, &String.upcase/1)
-    attr_taxes = Enum.filter(all_taxes, &(String.upcase(&1.name) in attr_taxes_names))
-
-    attr_taxes_names
-    |> Enum.reduce(changeset, &check_wrong_taxes(&1, &2, all_taxes_names))
-    |> put_assoc(:taxes, attr_taxes)
+    put_assoc(changeset, :taxes, Enum.map(taxes, &Commons.get_tax/1))
   end
 
   @spec check_wrong_taxes(String.t(), Ecto.Changeset.t(), [String.t()]) :: Ecto.Changeset.t()
   defp check_wrong_taxes(tax, changeset, taxes) do
-    if Enum.member?(taxes, tax) do
+    if MapSet.member?(taxes, tax) do
       changeset
     else
       add_error(changeset, :taxes, "The tax #{tax} is not defined")
     end
+  end
+
+  @spec get(map(), atom()) :: any()
+  defp get(map, key) when is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
   end
 end

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -104,7 +104,7 @@ defmodule Siwapp.Invoices.Item do
   @spec assoc_taxes(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp assoc_taxes(changeset, attrs) do
     attr_taxes = MapSet.new(get(attrs, :taxes) || [], &String.upcase/1)
-    current_taxes = MapSet.new(get_field(changeset, :taxes) || [], &(&1.name))
+    current_taxes = MapSet.new(get_field(changeset, :taxes) || [], & &1.name)
     new_taxes = MapSet.difference(attr_taxes, current_taxes)
 
     cond do
@@ -116,7 +116,7 @@ defmodule Siwapp.Invoices.Item do
 
   @spec put_taxes(Ecto.Changeset.t(), [MapSet.t()]) :: Ecto.Changeset.t()
   defp put_taxes(changeset, taxes) do
-    all_taxes = MapSet.new(Commons.list_taxes(:cache) || [], &(&1.name))
+    all_taxes = MapSet.new(Commons.list_taxes(:cache) || [], & &1.name)
     changeset = Enum.reduce(taxes, changeset, &check_wrong_taxes(&1, &2, all_taxes))
 
     put_assoc(changeset, :taxes, Enum.map(taxes, &Commons.get_tax/1))

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -150,7 +150,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
       item
       |> Map.take([:description, :discount, :quantity, :id])
       |> Mappable.to_map(keys: :strings)
-      |> Map.put("taxes", Enum.map(item.taxes, &(&1.name)))
+      |> Map.put("taxes", Enum.map(item.taxes, & &1.name))
       |> Map.put("virtual_unitary_cost", item.virtual_unitary_cost)
     end)
     |> Enum.with_index()

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -148,8 +148,10 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     items
     |> Enum.map(fn item ->
       item
-      |> Map.take([:description, :discount, :quantity, :virtual_unitary_cost, :id])
-      |> Map.put(:taxes, Commons.default_taxes_names())
+      |> Map.take([:description, :discount, :quantity, :id])
+      |> Mappable.to_map(keys: :strings)
+      |> Map.put("taxes", Enum.map(item.taxes, &(&1.name)))
+      |> Map.put("virtual_unitary_cost", item.virtual_unitary_cost)
     end)
     |> Enum.with_index()
     |> Enum.map(fn {item, i} -> {Integer.to_string(i), item} end)


### PR DESCRIPTION
- fixes #399 

Antes al introducir taxes pensaba que siempre eran nuevos. Ahora detecta si se están borrando, añadiendo o no haciendo nada, y según eso hace las queries.