### PR TITLE
Nurietzsche/forgotten buttons

### DIFF
--- a/lib/siwapp/templates.ex
+++ b/lib/siwapp/templates.ex
@@ -190,11 +190,26 @@ defmodule Siwapp.Templates do
   uses evaluated print_default template using invoice
   data.
   """
-  @spec pdf_content_and_name(Siwapp.Invoices.Invoice.t()) :: {binary, binary}
-  def pdf_content_and_name(invoice) do
+  @spec pdf_content_and_name(Siwapp.Invoices.Invoice.t() | [Siwapp.Invoices.Invoice.t()]) ::
+          {binary, binary}
+  def pdf_content_and_name(%Siwapp.Invoices.Invoice{} = invoice) do
     {:ok, data} = ChromicPDF.print_to_pdf({:html, print_str_template(invoice)})
 
     {Base.decode64!(data), "#{invoice.series.code}-#{invoice.number}.pdf"}
+  end
+
+  def pdf_content_and_name(invoices) do
+    to_print =
+      {:html,
+       Enum.reduce(invoices, "", fn invoice, acc -> print_str_template(invoice) <> acc end)}
+
+    {
+      to_print
+      |> ChromicPDF.print_to_pdf()
+      |> elem(1)
+      |> Base.decode64!(),
+      "invoices.pdf"
+    }
   end
 
   @doc """

--- a/lib/siwapp_web/controllers/page_controller.ex
+++ b/lib/siwapp_web/controllers/page_controller.ex
@@ -18,6 +18,15 @@ defmodule SiwappWeb.PageController do
     send_download(conn, {:binary, pdf_content}, filename: pdf_name)
   end
 
+  def download(conn, %{"ids" => ids}) do
+    {pdf_content, pdf_name} =
+      ids
+      |> Enum.map(&Invoices.get!(&1, preload: [{:items, :taxes}, :series]))
+      |> Templates.pdf_content_and_name()
+
+    send_download(conn, {:binary, pdf_content}, filename: pdf_name)
+  end
+
   @spec send_email(Plug.Conn.t(), map) :: Plug.Conn.t()
   def send_email(conn, %{"id" => id}) do
     invoice = Invoices.get!(id, preload: [{:items, :taxes}, :payments, :series])

--- a/lib/siwapp_web/live/invoices_live/index.html.heex
+++ b/lib/siwapp_web/live/invoices_live/index.html.heex
@@ -13,15 +13,18 @@
           data: [confirm: "Are you sure?"],
           class: "button is-danger"
         ) %>
-        <button class="button is-info">
-          Send Email
-        </button>
+        <%= link("Send Email",
+          to: "#",
+          phx_click: "send_email",
+          class: "button is-purple"
+        ) %>
         <button class="button is-info">
           Set Paid
         </button>
-        <button class="button is-info">
-          Download PDF
-        </button>
+        <%= link("Download PDf",
+          to: download_url(@checked),
+          class: "button is-info"
+        ) %>
         <button class="button is-info">
           Duplicate
         </button>

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -113,6 +113,7 @@ defmodule SiwappWeb.Router do
       live "/invoices", InvoicesLive.Index, :index
       live "/customers/:id/invoices", InvoicesLive.Index, :customer
       get "/invoices/:id/download", PageController, :download
+      get "/invoices/download/*ids", PageController, :download
       get "/invoices/:id/send_email", PageController, :send_email
 
       live "/customers/new", CustomersLive.Edit, :new

--- a/priv/repo/fixtures/print_default.html.heex
+++ b/priv/repo/fixtures/print_default.html.heex
@@ -47,6 +47,7 @@
         font-size: 100%;
         font-family: Helvetica, Arial, sans-serif;
         color: #3d3f3e;
+        page-break-after: always;
       }
 
       .logo {
@@ -210,6 +211,7 @@
     </style>
   </head>
   <body class="invoice">
+  <div class="invoice">
     <div class="row">
       <!-- here was company logo -->
       <div>
@@ -344,6 +346,7 @@
         </table>
       </div>
     </div>
+  </div>
   </body>
 </html>
 


### PR DESCRIPTION
He implementado las opciones de enviar facturas por correo y descargar desde el listado de facturas

- Send Email: No comprueba si cada factura ha sido enviada. Siempre devuelve el mismo flash.
- Download PDF: Funciona como en Siwapp Demo. Como la función send_download sólo está disponible en Controller y no LV, lo que hago es enviar los id's de las facturas seleccionadas en la url para luego recuperar esa lista en el PageController. Para ello podéis ver el pattern matching con "ids" que se define en el router.

fixes #409 