### PR TITLE
Use distinct instead of group by

### DIFF
--- a/lib/siwapp/searches/search_query.ex
+++ b/lib/siwapp/searches/search_query.ex
@@ -49,8 +49,7 @@ defmodule Siwapp.Searches.SearchQuery do
   end
 
   def filter_by(query, "key", value) do
-    query
-    |> join(:inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
+    join(query, :inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
       on: m.key == ^value
     )
   end

--- a/lib/siwapp/searches/search_query.ex
+++ b/lib/siwapp/searches/search_query.ex
@@ -53,7 +53,6 @@ defmodule Siwapp.Searches.SearchQuery do
     |> join(:inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
       on: m.key == ^value
     )
-    |> group_by([q], q.id)
   end
 
   def filter_by(query, "value", value) do
@@ -61,7 +60,7 @@ defmodule Siwapp.Searches.SearchQuery do
     |> join(:inner, [q], m in fragment("jsonb_each_text(?)", q.meta_attributes),
       on: m.value == ^value
     )
-    |> group_by([q], q.id)
+    |> distinct(true)
   end
 
   # Get invoices, customers or recurring_invoices by comparing value with name, email or id fields


### PR DESCRIPTION
Fallaba el group by al buscar por value. Lo he sustituido por distinct. Además, el group by para key no es necesario ya que solo puede haber un key única por cada invoice, recurring_invoice o customer