### PR TITLE
back buttons

### DIFF
--- a/lib/siwapp/invoices.ex
+++ b/lib/siwapp/invoices.ex
@@ -127,11 +127,10 @@ defmodule Siwapp.Invoices do
 
   @spec get!(pos_integer(), keyword()) :: Invoice.t()
   def get!(id, preload: list) do
-    invoice =
-      Invoice
-      |> Query.not_deleted()
-      |> Repo.get!(id)
-      |> Repo.preload(list)
+    Invoice
+    |> Query.not_deleted()
+    |> Repo.get!(id)
+    |> Repo.preload(list)
   end
 
   @doc """

--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -22,7 +22,6 @@ defmodule Siwapp.Searches do
     options = Keyword.merge(default, options)
 
     query
-    |> Query.not_deleted()
     |> limit(^options[:limit])
     |> offset(^options[:offset])
     |> order_by(^options[:order_by])

--- a/lib/siwapp/searches/search_query.ex
+++ b/lib/siwapp/searches/search_query.ex
@@ -23,6 +23,10 @@ defmodule Siwapp.Searches.SearchQuery do
     where(query, [q], q.number == type(^value, :integer))
   end
 
+  def filter_by(query, "customer_id", value) do
+    where(query, [q], q.customer_id == type(^value, :integer))
+  end
+
   def filter_by(query, "series", value) do
     query
     |> from(as: :query)

--- a/lib/siwapp_web/live/customers_live/edit.html.heex
+++ b/lib/siwapp_web/live/customers_live/edit.html.heex
@@ -12,7 +12,7 @@
   />
   <br>
   <%= submit("Save", class: "button is-success") %>
-  <%= live_patch("Back", to: Routes.customers_index_path(@socket, :index), class: "button is-dark") %>
+  <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
   <%= if @live_action == :edit do %>
     <button class="button is-danger" phx-click="delete">
       Delete

--- a/lib/siwapp_web/live/customers_live/index.ex
+++ b/lib/siwapp_web/live/customers_live/index.ex
@@ -13,12 +13,14 @@ defmodule SiwappWeb.CustomersLive.Index do
   alias Siwapp.Searches
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
+    query = Searches.filters_query(Customer, params)
+
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:query, Customer)
-     |> assign(customers: Customers.list_with_assoc_invoice_fields(Customer, 20))
+     |> assign(:query, query)
+     |> assign(customers: Customers.list_with_assoc_invoice_fields(query, 20))
      |> assign(page_title: "Customers")}
   end
 
@@ -46,13 +48,7 @@ defmodule SiwappWeb.CustomersLive.Index do
 
   @impl Phoenix.LiveView
   def handle_info({:search, params}, socket) do
-    query = Searches.filters_query(Customer, params)
-    customers = Customers.list_with_assoc_invoice_fields(query, 20)
-
-    {:noreply,
-     socket
-     |> assign(:query, query)
-     |> assign(:customers, customers)}
+    {:noreply, push_redirect(socket, to: Routes.customers_index_path(socket, :index, params))}
   end
 
   @spec due(integer, integer) :: integer

--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -146,7 +146,7 @@
           class: "button is-danger"
         ) %>
       <% end %>
-      <%= live_redirect("Back", to: Routes.invoices_index_path(@socket, :index), class: "button is-dark") %>
+      <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
       <%= if @live_action == :edit do %>
         <%= link("Send Email",
           to: Routes.page_path(@socket, :send_email, @invoice.id),

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.html.heex
@@ -162,10 +162,7 @@
           class: "button is-danger"
         ) %>
       <% end %>
-      <%= live_redirect("Back",
-        to: Routes.recurring_invoices_index_path(@socket, :index),
-        class: "button is-dark"
-      ) %>
+      <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
       <%= submit("Save", class: "button is-success") %>
     </div>
   </nav>

--- a/lib/siwapp_web/live/recurring_invoices_live/index.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/index.ex
@@ -8,14 +8,16 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
   alias Siwapp.Searches
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
+    query = Searches.filters_query(RecurringInvoice, params)
+
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:query, RecurringInvoice)
+     |> assign(:query, query)
      |> assign(
        :recurring_invoices,
-       RecurringInvoices.list(limit: 20, offset: 0, preload: [:series])
+       Searches.filters(query, preload: [:series])
      )
      |> assign(:checked, MapSet.new())
      |> assign(:page_title, "Recurring Invoices")}
@@ -57,13 +59,8 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
 
   @impl Phoenix.LiveView
   def handle_info({:search, params}, socket) do
-    query = Searches.filters_query(RecurringInvoice, params)
-    recurring_invoices = Searches.filters(query, preload: [:series])
-
     {:noreply,
-     socket
-     |> assign(:query, query)
-     |> assign(:recurring_invoices, recurring_invoices)}
+     push_redirect(socket, to: Routes.recurring_invoices_index_path(socket, :index, params))}
   end
 
   @spec update_checked(map(), Phoenix.LiveView.Socket.t()) :: MapSet.t()

--- a/lib/siwapp_web/live/series_live/form_component.html.heex
+++ b/lib/siwapp_web/live/series_live/form_component.html.heex
@@ -55,7 +55,7 @@
         <% end %>
       </p>
       <p class="control">
-        <%= live_redirect("Back", to: Routes.series_index_path(@socket, :index), class: "button is-dark") %>
+        <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
       </p>
       <p class="control">
         <%= submit("Save", class: "button is-success") %>

--- a/lib/siwapp_web/live/taxes_live/form_component.html.heex
+++ b/lib/siwapp_web/live/taxes_live/form_component.html.heex
@@ -53,7 +53,7 @@
         <% end %>
       </p>
       <p class="control">
-        <%= live_redirect("Back", to: Routes.taxes_index_path(@socket, :index), class: "button is-dark") %>
+        <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
       </p>
       <p class="control">
         <%= submit("Save", class: "button is-success") %>

--- a/lib/siwapp_web/live/templates_live/edit.html.heex
+++ b/lib/siwapp_web/live/templates_live/edit.html.heex
@@ -40,7 +40,7 @@
             class: "button is-danger"
           ) %>
         <% end %>
-        <%= live_redirect("Back", to: Routes.templates_index_path(@socket, :index), class: "button is-dark") %>
+        <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
         <%= submit("Save", class: "button is-success") %>
       </div>
     </nav>

--- a/lib/siwapp_web/router.ex
+++ b/lib/siwapp_web/router.ex
@@ -111,7 +111,7 @@ defmodule SiwappWeb.Router do
       live "/invoices/:id/edit", InvoicesLive.Edit, :edit
       get "/invoices/:id/show", PageController, :show_invoice
       live "/invoices", InvoicesLive.Index, :index
-      live "/customers/:id/invoices", InvoicesLive.Index, :customer
+      live "/customers/:customer_id/invoices", InvoicesLive.Index, :customer
       get "/invoices/:id/download", PageController, :download
       get "/invoices/download/*ids", PageController, :download
       get "/invoices/:id/send_email", PageController, :send_email

--- a/lib/siwapp_web/templates/page/show_invoice.html.heex
+++ b/lib/siwapp_web/templates/page/show_invoice.html.heex
@@ -1,6 +1,6 @@
 <nav class="navbar is-fixed-bottom navbar-menu" role="navigation" aria-label="main navigation">
   <div class="navbar-end navbar-items buttons">
-    <%= link("Back", to: Routes.invoices_index_path(@conn, :index), class: "button is-dark") %>
+    <%= link("Back", to: "#", onclick: "history.back()", class: "button is-dark") %>
     <%= link("Send Email",
       to: Routes.page_path(@conn, :send_email, @invoice.id),
       class: "button is-purple"


### PR DESCRIPTION
- fixes #319 
- Se ha quitado el Query.deleted_at() porque no funcionaba bien con customers y recurring invoices, se arreglará en #436 
- Se ha refactorizado un poco el index de invoices para que el listado de invoices asociados a un customer funcione igual que las búsquedas, entonces hay un solo mount :heart: 