### PR TITLE
fix searches.filters

### DIFF
--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -18,10 +18,11 @@ defmodule Siwapp.Searches do
   """
   @spec filters(Ecto.Queryable.t(), keyword()) :: [type_of_struct()]
   def filters(query, options \\ []) do
-    default = [limit: 20, offset: 0, preload: [], order_by: [desc: :id]]
+    default = [limit: 20, offset: 0, preload: [], order_by: [desc: :id], deleted_at_query: false]
     options = Keyword.merge(default, options)
 
     query
+    |> maybe_reject_deleted_at(options[:deleted_at_query])
     |> limit(^options[:limit])
     |> offset(^options[:offset])
     |> order_by(^options[:order_by])
@@ -44,5 +45,14 @@ defmodule Siwapp.Searches do
   @spec change(Search.t(), map) :: Ecto.Changeset.t()
   def change(%Search{} = search, attrs \\ %{}) do
     Search.changeset(search, attrs)
+  end
+
+  @spec maybe_reject_deleted_at(Ecto.Queryable.t(), boolean) :: Ecto.Queryable.t()
+  defp maybe_reject_deleted_at(query, boolean) do
+    if boolean do
+      where(query, [q], is_nil(q.deleted_at))
+    else
+      query
+    end
   end
 end

--- a/lib/siwapp/searches.ex
+++ b/lib/siwapp/searches.ex
@@ -22,7 +22,7 @@ defmodule Siwapp.Searches do
     options = Keyword.merge(default, options)
 
     query
-    |> maybe_reject_deleted_at(options[:deleted_at_query])
+    |> then(&if(options[:deleted_at_query], do: Query.not_deleted(&1), else: &1))
     |> limit(^options[:limit])
     |> offset(^options[:offset])
     |> order_by(^options[:order_by])
@@ -45,14 +45,5 @@ defmodule Siwapp.Searches do
   @spec change(Search.t(), map) :: Ecto.Changeset.t()
   def change(%Search{} = search, attrs \\ %{}) do
     Search.changeset(search, attrs)
-  end
-
-  @spec maybe_reject_deleted_at(Ecto.Queryable.t(), boolean) :: Ecto.Queryable.t()
-  defp maybe_reject_deleted_at(query, boolean) do
-    if boolean do
-      where(query, [q], is_nil(q.deleted_at))
-    else
-      query
-    end
   end
 end

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -19,7 +19,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     {:ok,
      socket
      |> assign(:page, 0)
-     |> assign(:invoices, Searches.filters(query, preload: [:series]))
+     |> assign(:invoices, Searches.filters(Invoice, preload: [:series], deleted_at_query: true))
      |> assign(:checked, MapSet.new())
      |> assign(:query, query)
      |> assign(:page_title, page_title)}
@@ -37,7 +37,12 @@ defmodule SiwappWeb.InvoicesLive.Index do
       :noreply,
       assign(socket,
         invoices:
-          invoices ++ Searches.filters(query, offset: (page + 1) * 20, preload: [:series]),
+          invoices ++
+            Searches.filters(query,
+              offset: (page + 1) * 20,
+              preload: [:series],
+              deleted_at_query: true
+            ),
         page: page + 1
       )
     }


### PR DESCRIPTION
Para usar la funcion Searches.filters con las invoices hay que añadir la opción deleted_at_query: true. Que por default está en false para que cuando se usa en el resto de sitios no haga esa query y pete