### PR TITLE
fixes taxes again

### DIFF
--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -100,17 +100,14 @@ defmodule Siwapp.Invoices.Item do
   @spec assoc_taxes(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp assoc_taxes(changeset, attrs) do
     attr_taxes_names = MapSet.new(get(attrs, :taxes) || [], &String.upcase/1)
-    current_taxes_names = MapSet.new(get_field(changeset, :taxes) || [], & &1.name)
-    put_taxes(changeset, attr_taxes_names)
-  end
 
-  @spec put_taxes(Ecto.Changeset.t(), MapSet.t()) :: Ecto.Changeset.t()
-  defp put_taxes(changeset, taxes_names) do
     all_taxes = Commons.list_taxes(:cache)
     all_taxes_names = MapSet.new(all_taxes, & &1.name)
-    changeset = Enum.reduce(taxes_names, changeset, &check_wrong_taxes(&1, &2, all_taxes_names))
 
-    put_assoc(changeset, :taxes, Enum.filter(all_taxes, &(&1.name in taxes_names)))
+    changeset =
+      Enum.reduce(attr_taxes_names, changeset, &check_wrong_taxes(&1, &2, all_taxes_names))
+
+    put_assoc(changeset, :taxes, Enum.filter(all_taxes, &(&1.name in attr_taxes_names)))
   end
 
   @spec check_wrong_taxes(String.t(), Ecto.Changeset.t(), MapSet.t()) :: Ecto.Changeset.t()

--- a/lib/siwapp/invoices/item.ex
+++ b/lib/siwapp/invoices/item.ex
@@ -101,12 +101,7 @@ defmodule Siwapp.Invoices.Item do
   defp assoc_taxes(changeset, attrs) do
     attr_taxes_names = MapSet.new(get(attrs, :taxes) || [], &String.upcase/1)
     current_taxes_names = MapSet.new(get_field(changeset, :taxes) || [], & &1.name)
-
-    if MapSet.equal?(attr_taxes_names, current_taxes_names) do
-      changeset
-    else
-      put_taxes(changeset, attr_taxes_names)
-    end
+    put_taxes(changeset, attr_taxes_names)
   end
 
   @spec put_taxes(Ecto.Changeset.t(), MapSet.t()) :: Ecto.Changeset.t()


### PR DESCRIPTION
- fxes #447

El error era que con ese if lo que hacía era que a veces no associara bien las taxes, y realmente no era necesario, se hace la asociación siempre y ya el changeset detecta si hay cambios con respecto al data o no.