### PR TITLE
Rodri/clear cache when updating taxes

### DIFF
--- a/lib/siwapp/commons.ex
+++ b/lib/siwapp/commons.ex
@@ -296,6 +296,8 @@ defmodule Siwapp.Commons do
   """
   @spec create_tax(map) :: {:ok, Tax.t()} | {:error, Ecto.Changeset.t()}
   def create_tax(attrs \\ %{}) do
+    Cachex.clear(:siwapp_cache)
+
     %Tax{}
     |> Tax.changeset(attrs)
     |> Repo.insert()
@@ -316,6 +318,8 @@ defmodule Siwapp.Commons do
   @spec update_tax(Tax.t(), map) ::
           {:ok, Tax.t()} | {:error, Ecto.Changeset.t()}
   def update_tax(%Tax{} = tax, attrs) do
+    Cachex.clear(:siwapp_cache)
+
     tax
     |> Tax.changeset(attrs)
     |> Repo.update()
@@ -355,6 +359,7 @@ defmodule Siwapp.Commons do
   """
   @spec delete_tax(Tax.t()) :: {:ok, Tax.t()} | {:error, Ecto.Changeset.t()}
   def delete_tax(%Tax{} = tax) do
+    Cachex.clear(:siwapp_cache)
     Repo.delete(tax)
   end
 

--- a/lib/siwapp/settings.ex
+++ b/lib/siwapp/settings.ex
@@ -17,6 +17,8 @@ defmodule Siwapp.Settings do
   """
   @spec create({atom | binary, binary}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
   def create({key, value}) do
+    Cachex.clear(:siwapp_cache)
+
     %Setting{}
     |> change({to_string(key), value})
     |> Repo.insert()
@@ -103,6 +105,8 @@ defmodule Siwapp.Settings do
   """
   @spec update({atom, any}) :: {:ok, Setting.t()} | {:error, Ecto.Changeset.t()}
   def update({key, value}) do
+    Cachex.clear(:siwapp_cache)
+
     key
     |> get()
     |> change({to_string(key), to_string(value)})

--- a/lib/siwapp/settings/setting_bundle.ex
+++ b/lib/siwapp/settings/setting_bundle.ex
@@ -58,10 +58,7 @@ defmodule Siwapp.Settings.SettingBundle do
 
   @spec validate_days_to_due(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp validate_days_to_due(changeset) do
-    days_to_due =
-      changeset
-      |> get_field(:days_to_due)
-      |> String.to_integer()
+    days_to_due = get_field(changeset, :days_to_due)
 
     if days_to_due >= 0 do
       changeset


### PR DESCRIPTION
Cuando editas, creas o eliminas un tax y luego creas una invoice no te cogía la nueva lista de taxes hasta que pasaran 5 minutos
Lo mismo pasaba si editas algún dato de los settings