### PR TITLE
removing unnusefull push_redirect

### DIFF
--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -74,7 +74,10 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully deleted")
-      |> push_redirect(to: Routes.invoices_index_path(socket, :index))
+      |> assign(
+        :invoices,
+        Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)
+      )
 
     {:noreply, socket}
   end
@@ -104,7 +107,10 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully duplicated")
-      |> push_redirect(to: Routes.invoices_index_path(socket, :index))
+      |> assign(
+        :invoices,
+        Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)
+      )
 
     {:noreply, socket}
   end
@@ -119,7 +125,10 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully paid")
-      |> push_redirect(to: Routes.invoices_index_path(socket, :index))
+      |> assign(
+        :invoices,
+        Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)
+      )
 
     {:noreply, socket}
   end

--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -74,6 +74,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully deleted")
+      |> assign(:checked, MapSet.new())
       |> assign(
         :invoices,
         Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)
@@ -107,6 +108,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully duplicated")
+      |> assign(:checked, MapSet.new())
       |> assign(
         :invoices,
         Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)
@@ -125,6 +127,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Invoices succesfully paid")
+      |> assign(:checked, MapSet.new())
       |> assign(
         :invoices,
         Searches.filters(socket.assigns.query, preload: [:series], deleted_at_query: true)

--- a/lib/siwapp_web/live/recurring_invoices_live/index.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/index.ex
@@ -68,7 +68,11 @@ defmodule SiwappWeb.RecurringInvoicesLive.Index do
     socket =
       socket
       |> put_flash(:info, "Recurring Invoices succesfully deleted")
-      |> push_redirect(to: Routes.recurring_invoices_index_path(socket, :index))
+      |> assign(:checked, MapSet.new())
+      |> assign(
+        :recurring_invoices,
+        Searches.filters(socket.assigns.query, preload: [:series])
+      )
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Como estaba antes si estabas usando los botones en las invoices de un customer luego te hacía redirect al index de invoices. Ahora simplemente se reasignan las invoices cambiadas nuevas o se quitan las eliminadas