### PR TITLE
fix deletes in invoice form

### DIFF
--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -154,6 +154,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     )
   end
 
+  @spec put_assoc_if_empty(map()) :: map()
   defp put_assoc_if_empty(params) do
     params
     |> then(&if Map.has_key?(&1, "items"), do: &1, else: Map.put(&1, "items", []))

--- a/lib/siwapp_web/live/invoices_live/edit.ex
+++ b/lib/siwapp_web/live/invoices_live/edit.ex
@@ -25,7 +25,7 @@ defmodule SiwappWeb.InvoicesLive.Edit do
     result =
       case socket.assigns.live_action do
         :new -> Invoices.create(params)
-        :edit -> Invoices.update(socket.assigns.invoice, params)
+        :edit -> Invoices.update(socket.assigns.invoice, put_assoc_if_empty(params))
       end
 
     case result do
@@ -152,6 +152,12 @@ defmodule SiwappWeb.InvoicesLive.Edit do
         "payments" => payments_as_params(invoice.payments)
       })
     )
+  end
+
+  defp put_assoc_if_empty(params) do
+    params
+    |> then(&if Map.has_key?(&1, "items"), do: &1, else: Map.put(&1, "items", []))
+    |> then(&if Map.has_key?(&1, "payments"), do: &1, else: Map.put(&1, "payments", []))
   end
 
   @spec items_as_params([Siwapp.Invoices.Item.t()]) :: map()

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.ex
@@ -26,8 +26,11 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
   def handle_event("save", %{"recurring_invoice" => params}, socket) do
     result =
       case socket.assigns.live_action do
-        :new -> RecurringInvoices.create(params)
-        :edit -> RecurringInvoices.update(socket.assigns.recurring_invoice, put_items_if_empty(params))
+        :new ->
+          RecurringInvoices.create(params)
+
+        :edit ->
+          RecurringInvoices.update(socket.assigns.recurring_invoice, put_items_if_empty(params))
       end
 
     case result do
@@ -107,6 +110,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
     )
   end
 
+  @spec put_items_if_empty(map()) :: map()
   defp put_items_if_empty(params) do
     if Map.has_key?(params, "items"), do: params, else: Map.put(params, "items", %{})
   end

--- a/lib/siwapp_web/live/recurring_invoices_live/edit.ex
+++ b/lib/siwapp_web/live/recurring_invoices_live/edit.ex
@@ -27,7 +27,7 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
     result =
       case socket.assigns.live_action do
         :new -> RecurringInvoices.create(params)
-        :edit -> RecurringInvoices.update(socket.assigns.recurring_invoice, params)
+        :edit -> RecurringInvoices.update(socket.assigns.recurring_invoice, put_items_if_empty(params))
       end
 
     case result do
@@ -105,6 +105,10 @@ defmodule SiwappWeb.RecurringInvoicesLive.Edit do
       :changeset,
       RecurringInvoices.change(recurring_invoice, %{"items" => recurring_invoice.items})
     )
+  end
+
+  defp put_items_if_empty(params) do
+    if Map.has_key?(params, "items"), do: params, else: Map.put(params, "items", %{})
   end
 
   # Replicates inputs_for behavior for recurring_invoice's items even when there's no association


### PR DESCRIPTION
- fixes #467 
- fixes #475

El asunto era que al eliminar todos los items/payments, en el HTML no aparecía ningún input respectivo a ellos, y en los params no aparecía el parámetro correspondiente, por lo que el changeset asumía que no había ningún cambio.

Lo que se ha hecho para arreglarlo es forzar en el edit que cuando no venga la clave items o payments, pues ponerla vacía.