### PR TITLE
improve set_paid

### DIFF
--- a/lib/siwapp_web/live/invoices_live/index.ex
+++ b/lib/siwapp_web/live/invoices_live/index.ex
@@ -122,6 +122,7 @@ defmodule SiwappWeb.InvoicesLive.Index do
     |> MapSet.to_list()
     |> List.delete(0)
     |> Enum.map(&Invoices.get!(&1, preload: [{:items, :taxes}, :payments]))
+    |> Enum.filter(&(!&1.paid))
     |> Enum.each(&Invoices.set_paid(&1))
 
     socket =


### PR DESCRIPTION
Si en las invoices marcadas existía una ya pagada se le añadía un pago con 0,00 $

Ahora se filtra primero la lista para coger solo las paid == false