### PR TITLE
Cambios necesarios:

### DIFF
--- a/lib/siwapp/invoices/invoice_query.ex
+++ b/lib/siwapp/invoices/invoice_query.ex
@@ -55,6 +55,7 @@ defmodule Siwapp.Invoices.InvoiceQuery do
   def last_number_with_series_id(query, series_id) do
     query
     |> where(series_id: ^series_id)
+    |> where([i], not is_nil(i.number))
     |> order_by(desc: :number)
     |> limit(1)
   end

--- a/priv/repo/migrations/20220207124821_create_customers.exs
+++ b/priv/repo/migrations/20220207124821_create_customers.exs
@@ -5,7 +5,7 @@ defmodule Siwapp.Repo.Migrations.CreateCustomers do
     create table(:customers) do
       add :name, :string, size: 100
       add :identification, :string, size: 50
-      add :hash_id, :string, size: 32
+      add :hash_id, :string, size: 100
       add :email, :string, size: 100
       add :contact_person, :string, size: 100
       add :invoicing_address, :text


### PR DESCRIPTION
- La db de Doofinder usa un hash_id de longitud 100. Lo he cambiado para
  que coincida la migración con las tablas usadas.
- Next_number_in_series no estaba cribando las invoices que tienen
  number NULL y al sumar uno a este, petaba