### PR TITLE
Pablo/redundant queries

### DIFF
--- a/lib/siwapp/invoices/statistics.ex
+++ b/lib/siwapp/invoices/statistics.ex
@@ -8,16 +8,6 @@ defmodule Siwapp.Invoices.Statistics do
   alias Siwapp.Query
   alias Siwapp.Repo
 
-  @spec count(Ecto.Queryable.t(), keyword()) :: non_neg_integer()
-  def count(query, options \\ []) do
-    default = [deleted_at_query: false]
-    options = Keyword.merge(default, options)
-
-    query
-    |> then(&if(options[:deleted_at_query], do: Query.not_deleted(&1), else: &1))
-    |> Repo.aggregate(:count)
-  end
-
   @doc """
   Returns a list of tuples, each containing the accumulated amount of money from all the invoices
   per day, for the given selection of 'invoices'.

--- a/lib/siwapp/invoices/statistics.ex
+++ b/lib/siwapp/invoices/statistics.ex
@@ -8,6 +8,16 @@ defmodule Siwapp.Invoices.Statistics do
   alias Siwapp.Query
   alias Siwapp.Repo
 
+  @spec count(Ecto.Queryable.t(), keyword()) :: non_neg_integer()
+  def count(query, options \\ []) do
+    default = [deleted_at_query: false]
+    options = Keyword.merge(default, options)
+
+    query
+    |> then(&if(options[:deleted_at_query], do: Query.not_deleted(&1), else: &1))
+    |> Repo.aggregate(:count)
+  end
+
   @doc """
   Returns a list of tuples, each containing the accumulated amount of money from all the invoices
   per day, for the given selection of 'invoices'.

--- a/lib/siwapp_web/live/search_live/search_component.ex
+++ b/lib/siwapp_web/live/search_live/search_component.ex
@@ -8,7 +8,7 @@ defmodule SiwappWeb.SearchLive.SearchComponent do
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
-    {:ok, assign(socket, series_names: Commons.list_series_names)}
+    {:ok, assign(socket, series_names: Commons.list_series_names())}
   end
 
   @impl Phoenix.LiveComponent

--- a/lib/siwapp_web/live/search_live/search_component.ex
+++ b/lib/siwapp_web/live/search_live/search_component.ex
@@ -7,11 +7,15 @@ defmodule SiwappWeb.SearchLive.SearchComponent do
   alias Siwapp.Searches.Search
 
   @impl Phoenix.LiveComponent
+  def mount(socket) do
+    {:ok, assign(socket, series_names: Commons.list_series_names)}
+  end
+
+  @impl Phoenix.LiveComponent
   def update(assigns, socket) do
     socket =
       socket
       |> assign_changeset(assigns)
-      |> assign(:series_names, Commons.list_series_names())
       |> assign(view: assigns.view)
 
     {:ok, socket}

--- a/test/siwapp/invoices/statistics_test.exs
+++ b/test/siwapp/invoices/statistics_test.exs
@@ -59,8 +59,8 @@ defmodule Siwapp.Invoices.StatisticsTest do
   end
 
   describe "get_amount_per_currencies/1" do
-    test "when there is no invoices it returns an empty map" do
-      assert Statistics.get_amount_per_currencies(:gross) == %{}
+    test "when there is no invoices it returns a tuple with an empty map and 0" do
+      assert Statistics.get_amount_per_currencies_and_count(:gross) == {%{}, 0}
     end
 
     test "for multiple invoices with different currencies, there is a key and an amount for each one" do
@@ -74,7 +74,8 @@ defmodule Siwapp.Invoices.StatisticsTest do
         currency: "GBP"
       })
 
-      assert Statistics.get_amount_per_currencies(:gross) == %{"USD" => 500, "GBP" => 500}
+      assert Statistics.get_amount_per_currencies_and_count(:gross) ==
+               {%{"USD" => 500, "GBP" => 500}, Decimal.new(2)}
     end
 
     test "for multiple invoices with the same currency, there is only one key and accumulated amount for them" do
@@ -88,7 +89,8 @@ defmodule Siwapp.Invoices.StatisticsTest do
         currency: "USD"
       })
 
-      assert Statistics.get_amount_per_currencies(:gross) == %{"USD" => 1000}
+      assert Statistics.get_amount_per_currencies_and_count(:gross) ==
+               {%{"USD" => 1000}, Decimal.new(2)}
     end
   end
 end


### PR DESCRIPTION
#537 He juntado dos queries de statistics en una sola y he usado el callback mount del search_component para evitar que se liste dos veces los nombres de las series