### PR TITLE
Some fixes

### DIFF
--- a/lib/siwapp_web/live/invoices_live/edit.html.heex
+++ b/lib/siwapp_web/live/invoices_live/edit.html.heex
@@ -20,7 +20,11 @@
       <div class="field">
         <%= label(f, :series_id, class: "label") %>
         <p class=" control select is-fullwidth">
-          <%= select(f, :series_id, Enum.map(@series, &{&1.name, &1.id})) %>
+          <%= if @live_action == :new do %>
+            <%= select(f, :series_id, Enum.map(@series, &[key: &1.name, value: &1.id, selected: &1.default])) %>
+          <% else %>
+            <%= select(f, :series_id, Enum.map(@series, &{&1.name, &1.id})) %>
+          <% end %>
         </p>
         <%= error_tag(f, :series_id) %>
       </div>

--- a/lib/siwapp_web/live/taxes_live/index.ex
+++ b/lib/siwapp_web/live/taxes_live/index.ex
@@ -19,6 +19,7 @@ defmodule SiwappWeb.TaxesLive.Index do
 
   @impl Phoenix.LiveView
   def handle_event("defaultClicked", %{"id" => id}, socket) do
+    Cachex.clear(:siwapp_cache)
     Commons.set_default_tax(id)
     taxes = Commons.list_taxes()
 


### PR DESCRIPTION
Se hace un clear de la caché porque si se selecciona una nueva tax por defecto y creas una nueva invoice mantiene la tax por defecto anterior.
En el caso de las series lo que ocurre es que el select siempre selecciona el primero en caso de que se creara una nueva invoice, y lo que se quiere es que seleccione la serie por defecto